### PR TITLE
Adding github actions framework for charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,32 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: lint
+          config: ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        with:
+          install_local_path_provisioner: true
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: install
+          config: ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          continue-after-seconds: 180
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      # See https://github.com/helm/chart-releaser-action/issues/6
+      - name: Install Helm
+        run: |
+          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0
+        with:
+          charts_repo_url: https://nextcloud.github.io/helm
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+helm-extra-args: --timeout 600s
+chart-dirs:
+  - charts
+chart-repos:
+  - nextcloud=https://nextcloud.github.io/helm
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
The purpose of this PR is to create the necessary github actions framework to properly lint & test new & changed charts as they arrive via pull requests.  It will also properly 'release' charts merged to the master branch in the form of a repo 'release' and publishing of the `index.yml` file on the branch publishing the github pages.


This will also require the repo maintainer to:

* enable the github pages feature in the [settings](https://github.com/nextcloud/helm/settings)
* create a github pages branch (ideally named `gh_pages`) if it doesn't already exist