### PR TITLE
Imports nextcloud helm chart from helm/stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# helm
+# Nextcloud Helm Charts
+
+[Helm](https://helm.sh) repo for different charts related to Nextcloud which can be installed on [Kubernetes](https://kubernetes.io)
+
+### Add Helm repository
+
+To install the repo just run:
+
+```bash
+helm repo add nextcloud https://nextcloud.github.io/helm/
+helm repo update
+```
+
+### Helm Charts
+
+* [nextcloud](https://nextcloud.github.io/helm/)
+
+  ```bash
+  helm install my-release nextcloud/nextcloud
+  ```

--- a/charts/nextcloud/.helmignore
+++ b/charts/nextcloud/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+name: nextcloud
+version: 2.0.0
+appVersion: 17.0.0
+description: A file sharing server that puts the control and security of your own data back into your hands.
+keywords:
+- nextcloud
+- storage
+- http
+- web
+- php
+home: https://nextcloud.com/
+icon: https://cdn.rawgit.com/docker-library/docs/defa5ffc7123177acd60ddef6e16bddf694cc35f/nextcloud/logo.svg
+sources:
+- https://github.com/nextcloud/helm
+- https://github.com/nextcloud/docker
+maintainers:
+- name: skjnldsv
+  email: skjnldsv@protonmail.com
+- name: chrisingenhaag
+  email: christian.ingenhaag@googlemail.com
+- name: billimek
+  email: jeff@billimek.com

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -1,0 +1,243 @@
+# nextcloud
+
+[nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
+
+## TL;DR;
+
+```console
+helm repo add nextcloud https://nextcloud.github.io/helm/
+helm install my-release nextcloud/nextcloud
+```
+
+## Introduction
+
+This chart bootstraps an [nextcloud](https://hub.docker.com/_/nextcloud/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the nextcloud application.
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm repo add nextcloud https://nextcloud.github.io/helm/
+helm install my-release nextcloud/nextcloud
+```
+
+The command deploys nextcloud on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the nextcloud chart and their default values.
+
+| Parameter                                                    | Description                                             | Default                                     |
+| ------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------- |
+| `image.repository`                                           | nextcloud Image name                                    | `nextcloud`                                 |
+| `image.tag`                                                  | nextcloud Image tag                                     | `{VERSION}`                                 |
+| `image.pullPolicy`                                           | Image pull policy                                       | `IfNotPresent`                              |
+| `image.pullSecrets`                                          | Specify image pull secrets                              | `nil`                                       |
+| `ingress.enabled`                                            | Enable use of ingress controllers                       | `false`                                     |
+| `ingress.servicePort`                                        | Ingress' backend servicePort                            | `http`                                      |
+| `ingress.annotations`                                        | An array of service annotations                         | `nil`                                       |
+| `ingress.labels`                                             | An array of service labels                              | `nil`                                       |
+| `ingress.tls`                                                | Ingress TLS configuration                               | `[]`                                        |
+| `nextcloud.host`                                             | nextcloud host to create application URLs               | `nextcloud.kube.home`                       |
+| `nextcloud.username`                                         | User of the application                                 | `admin`                                     |
+| `nextcloud.password`                                         | Application password                                    | `changeme`                                  |
+| `nextcloud.update`                                           | Trigger update if custom command is used                | `0`                                         |
+| `nextcloud.datadir`                                          | nextcloud data dir location                             | `/var/www/html/data`                        |
+| `nextcloud.tableprefix`                                      | nextcloud db table prefix                               | `''`                                        |
+| `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                | `false`                                     |
+| `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                          | `nil`                                       |
+| `nextcloud.mail.domain`                                      | nextcloud mail domain                                   | `nil`                                       |
+| `nextcloud.mail.smtp.host`                                   | SMTP hostname                                           | `nil`                                       |
+| `nextcloud.mail.smtp.secure`                                 | SMTP connection `ssl` or empty                          | `''`                                        |
+| `nextcloud.mail.smtp.port`                                   | Optional SMTP port                                      | `nil`                                       |
+| `nextcloud.mail.smtp.authtype`                               | SMTP authentication method                              | `LOGIN`                                     |
+| `nextcloud.mail.smtp.name`                                   | SMTP username                                           | `''`                                        |
+| `nextcloud.mail.smtp.password`                               | SMTP password                                           | `''`                                        |
+| `nextcloud.configs`                                          | Config files created in `/var/www/html/config`          | `{}`                                        |
+| `nextcloud.persistence.subPath`                              | Set the subPath for nextcloud to use in volume          | `nil`                                       |
+| `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d` | `{}`                                        |
+| `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`     | `true`                                      |
+| `nextcloud.defaultConfigs.\.redis\.config\.php`              | Default Redis configuration                             | `true`                                      |
+| `nextcloud.defaultConfigs.\.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls           | `true`                                      |
+| `nextcloud.defaultConfigs.\.apcu\.config\.php`               | Default configuration to define APCu as local cache     | `true`                                      |
+| `nextcloud.defaultConfigs.\.apps\.config\.php`               | Default configuration for apps                          | `true`                                      |
+| `nextcloud.defaultConfigs.\.autoconfig\.php`                 | Default auto-configuration for databases                | `true`                                      |
+| `nextcloud.defaultConfigs.\.smtp\.config\.php`               | Default configuration for smtp                          | `true`                                      |
+| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                                      |
+| `nextcloud.extraEnv`                                         | specify additional environment variables                | `{}`                                        |
+| `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod        | `{}`                                        |
+| `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod  | `{}`                                        |
+| `nginx.enabled`                                              | Enable nginx (requires you use php-fpm image)           | `false`                                     |
+| `nginx.image.repository`                                     | nginx Image name                                        | `nginx`                                     |
+| `nginx.image.tag`                                            | nginx Image tag                                         | `alpine`                                    |
+| `nginx.image.pullPolicy`                                     | nginx Image pull policy                                 | `IfNotPresent`                              |
+| `nginx.config.default`                                       | Whether to use nextclouds recommended nginx config      | `true`                                      |
+| `nginx.config.custom`                                        | Specify a custom config for nginx                       | `{}`                                        |
+| `nginx.resources`                                            | nginx resources                                         | `{}`                                        |
+| `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand      | `nil`                                       |
+| `lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand        | `nil`                                       |
+| `internalDatabase.enabled`                                   | Whether to use internal sqlite database                 | `true`                                      |
+| `internalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
+| `externalDatabase.enabled`                                   | Whether to use external database                        | `false`                                     |
+| `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`           | `mysql`                                     |
+| `externalDatabase.host`                                      | Host of the external database                           | `nil`                                       |
+| `externalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
+| `externalDatabase.user`                                      | Existing username in the external db                    | `nextcloud`                                 |
+| `externalDatabase.password`                                  | Password for the above username                         | `nil`                                       |
+| `externalDatabase.existingSecret.enabled`                    | Whether to use a existing secret or not                 | `false`                                     |
+| `externalDatabase.existingSecret.secretName`                 | Name of the existing secret                             | `nil`                                       |
+| `externalDatabase.existingSecret.usernameKey`                | Name of the key that contains the username              | `nil`                                       |
+| `externalDatabase.existingSecret.passwordKey`                | Name of the key that contains the password              | `nil`                                       |
+| `mariadb.enabled`                                            | Whether to use the MariaDB chart                        | `false`                                     |
+| `mariadb.db.name`                                            | Database name to create                                 | `nextcloud`                                 |
+| `mariadb.db.password`                                        | Password for the database                               | `changeme`                                  |
+| `mariadb.db.user`                                            | Database user to create                                 | `nextcloud`                                 |
+| `mariadb.rootUser.password`                                  | MariaDB admin password                                  | `nil`                                       |
+| `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                     |
+| `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                     |
+| `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                              |
+| `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                          |
+| `cronjob.curlInsecure`                                       | Set insecure (-k) option to curl                        | false                                       |
+| `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep               | `5`                                         |
+| `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep            | `2`                                         |
+| `cronjob.resources`                                          | Cronjob Resources                                       | `nil`                                       |
+| `cronjob.nodeSelector`                                       | Cronjob Node selector                                   | `nil`                                       |
+| `cronjob.tolerations`                                        | Cronjob tolerations                                     | `nil`                                       |
+| `cronjob.affinity`                                           | Cronjob affinity                                        | `nil`                                       |
+| `service.type`                                               | Kubernetes Service type                                 | `ClusterIp`                                 |
+| `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer            | `nil`                                       |
+| `service.nodePort`                                           | NodePort for service type NodePort                      | `nil`                                       |
+| `persistence.enabled`                                        | Enable persistence using PVC                            | `false`                                     |
+| `persistence.annotations`                                    | PVC annotations                                         | `{}`                                        |
+| `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                  | `nil` (uses alpha storage class annotation) |
+| `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume               | `nil` (uses alpha storage class annotation) |
+| `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                    | `ReadWriteOnce`                             |
+| `persistence.size`                                           | PVC Storage Request for nextcloud volume                | `8Gi`                                       |
+| `resources`                                                  | CPU/Memory resource requests/limits                     | `{}`                                        |
+| `livenessProbe.enabled`                                      | Turn on and off liveness probe                          | `true`                                      |
+| `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                | `30`                                        |
+| `livenessProbe.periodSeconds`                                | How often to perform the probe                          | `15`                                        |
+| `livenessProbe.timeoutSeconds`                               | When the probe times out                                | `5`                                         |
+| `livenessProbe.failureThreshold`                             | Minimum consecutive failures for the probe              | `3`                                         |
+| `livenessProbe.successThreshold`                             | Minimum consecutive successes for the probe             | `1`                                         |
+| `readinessProbe.enabled`                                     | Turn on and off readiness probe                         | `true`                                      |
+| `readinessProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated               | `30`                                        |
+| `readinessProbe.periodSeconds`                               | How often to perform the probe                          | `15`                                        |
+| `readinessProbe.timeoutSeconds`                              | When the probe times out                                | `5`                                         |
+| `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe              | `3`                                         |
+| `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                         |
+| `hpa.enabled`                                                | Boolean to create a HorizontalPodAutoscaler             | `false`                                     |
+| `hpa.cputhreshold`                                           | CPU threshold percent for the HorizontalPodAutoscale    | `60`                                        |
+| `hpa.minPods`                                                | Min. pods for the Nextcloud HorizontalPodAutoscaler     | `1`                                         |
+| `hpa.maxPods`                                                | Max. pods for the Nextcloud HorizontalPodAutoscaler     | `10`                                        |
+| `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level           | not set                                     |
+| `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                     |
+| `metrics.enabled`                                            | Start Prometheus metrics exporter                       | `false`                                     |
+| `metrics.https`                                              | Defines if https is used to connect to nextcloud        | `false` (uses http)                         |
+| `metrics.timeout`                                            | When the scrape times out                               | `5s`                                        |
+| `metrics.image.repository`                                   | Nextcloud metrics exporter image name                   | `xperimental/nextcloud-exporter`            |
+| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                    | `v0.3.0`                                    |
+| `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy            | `IfNotPresent`                              |
+| `metrics.podAnnotations`                                     | Additional annotations for metrics exporter             | not set                                     |
+| `metrics.podLabels`                                          | Additional labels for metrics exporter                  | not set                                     |
+| `metrics.service.type`                                       | Metrics: Kubernetes Service type                        | `ClusterIP`                                 |
+| `metrics.service.loadBalancerIP`                             | Metrics: LoadBalancerIp for service type LoadBalancer   | `nil`                                       |
+| `metrics.service.nodePort`                                   | Metrics: NodePort for service type NodePort             | `nil`                                       |
+| `metrics.service.annotations`                                | Additional annotations for service metrics exporter     | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
+| `metrics.service.labels`                                     | Additional labels for service metrics exporter          | `{}`                                        |
+
+> **Note**:
+>
+> For nextcloud to function correctly, you should specify the `nextcloud.host` parameter to specify the FQDN (recommended) or the public IP address of the nextcloud service.
+>
+> Optionally, you can specify the `service.loadBalancerIP` parameter to assign a reserved IP address to the nextcloud service of the chart. However please note that this feature is only available on a few cloud providers (f.e. GKE).
+>
+> To reserve a public IP address on GKE:
+>
+> ```bash
+> gcloud compute addresses create nextcloud-public-ip
+> ```
+>
+> The reserved IP address can be associated to the nextcloud service by specifying it as the value of the `service.loadBalancerIP` parameter while installing the chart.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name my-release \
+  --set nextcloud.username=admin,nextcloud.password=password,mariadb.rootUser.password=secretpassword \
+    nextcloud/nextcloud
+```
+
+The above command sets the nextcloud administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-release -f values.yaml nextcloud/nextcloud
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Configuration](#configuration) section to enable persistence and configuration of the PVC.
+
+## Cronjob
+
+This chart can utilize Kubernetes `CronJob` resource to execute [background tasks](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html).
+
+To use this functionality, set `cronjob.enabled` parameter to `true` and switch background mode to Webcron in your nextcloud settings page.
+See the [Configuration](#configuration) section for further configuration of the cronjob resource.
+
+> **Note**: For the cronjobs to work correctly, ingress must be also enabled (set `ingress.enabled` to `true`) and `nextcloud.host` has to be publicly resolvable.
+
+## Multiple config.php file
+
+Nextcloud supports loading configuration parameters from multiple files.
+You can add arbitrary files ending with `.config.php` in the `config/` directory.
+See [documentation](https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file).
+
+For example, following config will configure Nextcloud with [S3 as primary storage](https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) by creating file `/var/www/html/config/s3.config.php`:
+
+```yaml
+nextcloud:
+  configs:
+    s3.config.php: |-
+      <?php
+      $CONFIG = array (
+        'objectstore' => array(
+          'class' => '\\OC\\Files\\ObjectStore\\S3',
+          'arguments' => array(
+            'bucket'     => 'my-bucket',
+            'autocreate' => true,
+            'key'        => 'xxx',
+            'secret'     => 'xxx',
+            'region'     => 'us-east-1',
+            'use_ssl'    => true
+          )
+        )
+      );
+```

--- a/charts/nextcloud/requirements.lock
+++ b/charts/nextcloud/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 7.1.0
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 10.0.1
+digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
+generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/charts/nextcloud/requirements.yaml
+++ b/charts/nextcloud/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  version: ~7.1.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled
+- name: redis
+  version: ~10.0.1
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: redis.enabled

--- a/charts/nextcloud/templates/NOTES.txt
+++ b/charts/nextcloud/templates/NOTES.txt
@@ -1,0 +1,94 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
+{{- if empty .Values.nextcloud.host -}}
+#################################################################################
+### WARNING: You did not provide an external host in your 'helm install' call ###
+#################################################################################
+
+This deployment will be incomplete until you configure nextcloud with a resolvable
+host. To configure nextcloud with the URL of your service:
+
+1. Get the nextcloud URL by running:
+
+  {{- if contains "NodePort" .Values.service.type }}
+
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nextcloud.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+  {{- if .Values.mariadb.db.password }}
+  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  {{- end }}
+  {{- end }}
+
+2. Complete your nextcloud deployment by running:
+
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.host=$APP_HOST,nextcloud.password=$APP_PASSWORD{{ if .Values.mariadb.db.password }},mariadb.db.password=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.password=$APP_PASSWORD,nextcloud.host=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
+
+{{- else -}}
+1. Get the nextcloud URL by running:
+
+{{- if eq .Values.service.type "ClusterIP" }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "nextcloud.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:8080
+{{- else }}
+
+  echo http://{{ .Values.nextcloud.host }}/
+{{- end }}
+
+2. Get your nextcloud login credentials by running:
+
+  echo User:     {{ .Values.nextcloud.username }}
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+#######################################################################################################
+## WARNING: You did not provide an external database host in your 'helm install' call                ##
+## Running Nextcloud with the integrated sqlite database is not recommended for production instances ##
+#######################################################################################################
+
+For better performance etc. you have to configure nextcloud with a resolvable database
+host. To configure nextcloud to use and external database host:
+
+
+1. Complete your nextcloud deployment by running:
+
+{{- if contains "NodePort" .Values.service.type }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nextcloud.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.password=$APP_PASSWORD,nextcloud.host=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
+{{- end }}

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nextcloud.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nextcloud.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nextcloud.mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified redis app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nextcloud.redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nextcloud.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/nextcloud/templates/config.yaml
+++ b/charts/nextcloud/templates/config.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.nextcloud.configs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.nextcloud.configs }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- if .Values.nextcloud.defaultConfigs }}
+{{- if index .Values.nextcloud.defaultConfigs ".htaccess" }}
+  .htaccess: |-
+    # line below if for Apache 2.4
+    <ifModule mod_authz_core.c>
+    Require all denied
+    </ifModule>
+    # line below if for Apache 2.2
+    <ifModule !mod_authz_core.c>
+    deny from all
+    </ifModule>
+    # section for Apache 2.2 and 2.4
+    <ifModule mod_autoindex.c>
+    IndexIgnore *
+    </ifModule>
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "redis.config.php" }}
+  redis.config.php: |-
+    <?php
+    if (getenv('REDIS_HOST')) {
+      $CONFIG = array (
+        'memcache.distributed' => '\OC\Memcache\Redis',
+        'memcache.locking' => '\OC\Memcache\Redis',
+        'redis' => array(
+          'host' => getenv('REDIS_HOST'),
+          'port' => getenv('REDIS_HOST_PORT') ?: 6379,
+        ),
+      );
+    }
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apache-pretty-urls.config.php" }}
+  apache-pretty-urls.config.php: |-
+    <?php
+    $CONFIG = array (
+      'htaccess.RewriteBase' => '/',
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apcu.config.php" }}
+  apcu.config.php: |-
+    <?php
+    $CONFIG = array (
+      'memcache.local' => '\OC\Memcache\APCu',
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apps.config.php" }}
+  apps.config.php: |-
+    <?php
+    $CONFIG = array (
+      "apps_paths" => array (
+          0 => array (
+                  "path"     => OC::$SERVERROOT."/apps",
+                  "url"      => "/apps",
+                  "writable" => false,
+          ),
+          1 => array (
+                  "path"     => OC::$SERVERROOT."/custom_apps",
+                  "url"      => "/custom_apps",
+                  "writable" => true,
+          ),
+      ),
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "autoconfig.php" }}
+  autoconfig.php: |-
+    <?php
+    $autoconfig_enabled = false;
+    if (getenv('SQLITE_DATABASE')) {
+        $AUTOCONFIG["dbtype"] = "sqlite";
+        $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+        $autoconfig_enabled = true;
+    } elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+        $AUTOCONFIG["dbtype"] = "mysql";
+        $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+        $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+        $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+        $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+        $autoconfig_enabled = true;
+    } elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+        $AUTOCONFIG["dbtype"] = "pgsql";
+        $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+        $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+        $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+        $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+        $autoconfig_enabled = true;
+    }
+    if ($autoconfig_enabled) {
+        if (getenv('NEXTCLOUD_TABLE_PREFIX')) {
+            $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX');
+        }
+        $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+    }
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "smtp.config.php" }}
+  smtp.config.php: |-
+    <?php
+    if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+      $CONFIG = array (
+        'mail_smtpmode' => 'smtp',
+        'mail_smtphost' => getenv('SMTP_HOST'),
+        'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+        'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+        'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+        'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+        'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+        'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+        'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+        'mail_domain' => getenv('MAIL_DOMAIN'),
+      );
+    }
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.cronjob.annotations | indent 4 }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  concurrencyPolicy: Forbid
+  {{- with .Values.cronjob.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ . }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+        spec:
+          restartPolicy: Never
+          {{- if (default .Values.image.pullSecrets .Values.cronjob.image.pullSecrets) }}
+          imagePullSecrets:
+          {{- range (default .Values.image.pullSecrets .Values.cronjob.image.pullSecrets) }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ default .Values.image.repository .Values.cronjob.image.repository }}:{{ default .Values.image.tag .Values.cronjob.image.tag }}"
+              imagePullPolicy: {{ default .Values.image.pullPolicy .Values.cronjob.image.pullPolicy }}
+              command: [ "curl" ]
+              args:
+              {{- if .Values.cronjob.curlInsecure }}
+                - "-k"
+              {{- end }}
+                - "--fail"
+                - "-L"
+              {{- if .Values.ingress.tls }}
+                - "https://{{ .Values.nextcloud.host }}/cron.php"
+              {{- else }}
+                - "http://{{ .Values.nextcloud.host }}/cron.php"
+              {{- end }}
+              resources:
+{{ toYaml (default .Values.resources .Values.cronjob.resources) | indent 16 }}
+    {{- with (default .Values.nodeSelector .Values.cronjob.nodeSelector) }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with (default .Values.affinity .Values.cronjob.affinity) }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with (default .Values.tolerations .Values.cronjob.tolerations) }}
+          tolerations:
+{{ toYaml . | indent 12 }}:
+    {{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/db-secret.yaml
+++ b/charts/nextcloud/templates/db-secret.yaml
@@ -1,0 +1,22 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.enabled }}
+{{- if not .Values.externalDatabase.existingSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "db"  }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.mariadb.enabled }}
+  db-password: {{ default "" .Values.mariadb.db.password | b64enc | quote }}
+  db-username: {{ default "" .Values.mariadb.db.user | b64enc | quote }}
+  {{- else }}
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  db-username: {{ default "" .Values.externalDatabase.user | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -1,0 +1,357 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+{{ toYaml .Values.nextcloud.strategy | indent 4 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.redis.enabled }}
+        {{ template "nextcloud.redis.fullname" . }}-client: "true"
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.lifecycle }}
+        lifecycle:
+        {{-   if .Values.lifecycle.postStartCommand }}
+          postStart:
+            exec:
+              command:
+                {{- toYaml .Values.lifecycle.postStartCommand | nindent 16 -}}
+        {{-   end }}
+        {{-   if .Values.lifecycle.preStopCommand }}
+          preStop:
+            exec:
+              command:
+                {{- toYaml .Values.lifecycle.preStopCommand | nindent 16 -}}
+        {{-   end }}
+        {{- end }}
+        env:
+        {{- if .Values.internalDatabase.enabled }}
+        - name: SQLITE_DATABASE
+          value: {{ .Values.internalDatabase.name | quote }}
+        {{- else if .Values.mariadb.enabled }}
+        - name: MYSQL_HOST
+          value: {{ template "nextcloud.mariadb.fullname" . }}
+        - name: MYSQL_DATABASE
+          value: {{ .Values.mariadb.db.name | quote }}
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
+        {{- else }}
+          {{- if eq .Values.externalDatabase.type "postgresql" }}
+        - name: POSTGRES_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: POSTGRES_DB
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
+          {{- else }}
+        - name: MYSQL_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MYSQL_DATABASE
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
+          {{- end }}
+        {{- end }}
+        - name: NEXTCLOUD_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-username
+        - name: NEXTCLOUD_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-password
+        - name: NEXTCLOUD_TRUSTED_DOMAINS
+          value: {{ .Values.nextcloud.host }}
+        {{- if ne (int .Values.nextcloud.update) 0 }}
+        - name: NEXTCLOUD_UPDATE
+          value: {{ .Values.nextcloud.update | quote }}
+        {{- end }}
+        - name: NEXTCLOUD_DATA_DIR
+          value: {{ .Values.nextcloud.datadir | quote }}
+        {{- if .Values.nextcloud.tableprefix }}
+        - name: NEXTCLOUD_TABLE_PREFIX
+          value: {{ .Values.nextcloud.tableprefix | quote }}
+        {{- end }}
+        {{- if .Values.nextcloud.mail.enabled }}
+        - name: MAIL_FROM_ADDRESS
+          value: {{ .Values.nextcloud.mail.fromAddress | quote }}
+        - name: MAIL_DOMAIN
+          value: {{ .Values.nextcloud.mail.domain | quote }}
+        - name: SMTP_HOST
+          value: {{ .Values.nextcloud.mail.smtp.host | quote }}
+        - name: SMTP_SECURE
+          value: {{ .Values.nextcloud.mail.smtp.secure | quote }}
+        - name: SMTP_PORT
+          value: {{ .Values.nextcloud.mail.smtp.port | quote }}
+        - name: SMTP_AUTHTYPE
+          value: {{ .Values.nextcloud.mail.smtp.authtype | quote }}
+        - name: SMTP_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: smtp-username
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: smtp-password
+        {{- end }}
+        {{- if .Values.redis.enabled }}
+        - name: REDIS_HOST
+          value: {{ template "nextcloud.redis.fullname" . }}-master
+        - name: REDIS_HOST_PORT
+          value: {{ .Values.redis.redisPort | quote }}
+        {{- end }}
+        {{- if .Values.nextcloud.extraEnv }}
+{{ toYaml .Values.nextcloud.extraEnv | indent 8 }}
+        {{- end }}
+        {{- if not .Values.nginx.enabled }}
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        {{- end }}
+        {{- if and .Values.livenessProbe.enabled (not .Values.nginx.enabled) }}
+        livenessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.nextcloud.host | quote }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if and .Values.readinessProbe.enabled (not .Values.nginx.enabled) }}
+        readinessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.nextcloud.host | quote }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: nextcloud-data
+          mountPath: /var/www/
+          subPath: {{ ternary "root" (printf "%s/%s" .Values.nextcloud.persistence.subPath "root") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html
+          subPath: {{ ternary "html" (printf "%s/%s" .Values.nextcloud.persistence.subPath "html") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: {{ .Values.nextcloud.datadir }}
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.nextcloud.persistence.subPath "data") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/config
+          subPath: {{ ternary "config" (printf "%s/%s" .Values.nextcloud.persistence.subPath "config") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/custom_apps
+          subPath: {{ ternary "custom_apps" (printf "%s/%s" .Values.nextcloud.persistence.subPath "custom_apps") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/tmp
+          subPath: {{ ternary "tmp" (printf "%s/%s" .Values.nextcloud.persistence.subPath "tmp") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/themes
+          subPath: {{ ternary "themes" (printf "%s/%s" .Values.nextcloud.persistence.subPath "themes") (empty .Values.nextcloud.persistence.subPath) }}
+        {{- range $key, $value := .Values.nextcloud.configs }}
+        - name: nextcloud-config
+          mountPath: /var/www/html/config/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        {{- if .Values.nextcloud.configs }}
+        {{- range $key, $value := .Values.nextcloud.defaultConfigs }}
+        {{- if $value }}
+        - name: nextcloud-config
+          mountPath: /var/www/html/config/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- range $key, $value := .Values.nextcloud.phpConfigs }}
+        - name: nextcloud-phpconfig
+          mountPath: /usr/local/etc/php/conf.d/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        {{- if .Values.nextcloud.extraVolumeMounts }}
+{{ toYaml .Values.nextcloud.extraVolumeMounts | indent 8 }}
+        {{- end }}
+        {{- if .Values.nginx.enabled }}
+      - name: {{ .Chart.Name }}-nginx
+        image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+        imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.nextcloud.host | quote }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.nextcloud.host | quote }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.nginx.resources | indent 10 }}
+        volumeMounts:
+        - name: nextcloud-data
+          mountPath: /var/www/
+          subPath: {{ ternary "root" (printf "%s/%s" .Values.nextcloud.persistence.subPath "root") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html
+          subPath: {{ ternary "html" (printf "%s/%s" .Values.nextcloud.persistence.subPath "html") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: {{ .Values.nextcloud.datadir }}
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.nextcloud.persistence.subPath "data") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/config
+          subPath: {{ ternary "config" (printf "%s/%s" .Values.nextcloud.persistence.subPath "config") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/custom_apps
+          subPath: {{ ternary "custom_apps" (printf "%s/%s" .Values.nextcloud.persistence.subPath "custom_apps") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/tmp
+          subPath: {{ ternary "tmp" (printf "%s/%s" .Values.nextcloud.persistence.subPath "tmp") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-data
+          mountPath: /var/www/html/themes
+          subPath: {{ ternary "themes" (printf "%s/%s" .Values.nextcloud.persistence.subPath "themes") (empty .Values.nextcloud.persistence.subPath) }}
+        - name: nextcloud-nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+      - name: nextcloud-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.nextcloud.configs }}
+      - name: nextcloud-config
+        configMap:
+          name: {{ template "nextcloud.fullname" . }}-config
+      {{- end }}
+      {{- if .Values.nextcloud.phpConfigs }}
+      - name: nextcloud-phpconfig
+        configMap:
+          name: {{ template "nextcloud.fullname" . }}-phpconfig
+      {{- end }}
+      {{- if .Values.nginx.enabled }}
+      - name: nextcloud-nginx-config
+        configMap:
+          name: {{ template "nextcloud.fullname" . }}-nginxconfig
+      {{- end }}
+      {{- if .Values.nextcloud.extraVolumes }}
+{{ toYaml .Values.nextcloud.extraVolumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.nginx.enabled }}
+      # Will mount configuration files as www-data (id: 82) for nextcloud
+      securityContext:
+        fsGroup: 82
+      {{- else }}
+      # Will mount configuration files as www-data (id: 33) for nextcloud
+      securityContext:
+        fsGroup: 33
+      {{- end }}

--- a/charts/nextcloud/templates/hpa.yaml
+++ b/charts/nextcloud/templates/hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.hpa.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "nextcloud.fullname" . }}
+  minReplicas: {{ .Values.hpa.minPods }}
+  maxReplicas: {{ .Values.hpa.maxPods }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.cputhreshold }}
+{{- end }}

--- a/charts/nextcloud/templates/ingress.yaml
+++ b/charts/nextcloud/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - host: {{ .Values.nextcloud.host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "nextcloud.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: metrics
+spec:
+  replicas: {{ .Values.metrics.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations: {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: metrics
+      {{- if .Values.metrics.podLabels }}
+{{ toYaml .Values.metrics.podLabels | indent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+        env:
+        - name: NEXTCLOUD_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-username
+        - name: NEXTCLOUD_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-password
+        - name: NEXTCLOUD_SERVER
+          value: http{{ if .Values.metrics.https }}s{{ end }}://{{ .Values.nextcloud.host }}
+        - name: NEXTCLOUD_TIMEOUT
+          value: {{ .Values.metrics.timeout }}
+        ports:
+        - name: metrics
+          containerPort: 9205
+        {{- if .Values.metrics.resources }}
+        resources: {{- toYaml .Values.metrics.resources | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/metrics-service.yaml
+++ b/charts/nextcloud/templates/metrics-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-metrics
+  labels:
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.metrics.service.labels -}}
+    {{ toYaml .Values.metrics.service.labels | nindent 4 }}
+    {{- end -}}
+  {{- if .Values.metrics.service.annotations }}
+  annotations: {{ toYaml .Values.metrics.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{ if eq .Values.metrics.service.type "LoadBalancer" -}} {{ if .Values.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{ end -}}
+  {{- end -}}
+  ports:
+  - name: metrics
+    port: 9205
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/nextcloud/templates/nextcloud-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-pvc.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-nextcloud
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -1,0 +1,185 @@
+{{- if .Values.nginx.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-nginxconfig
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  nginx.conf: |-
+{{- if .Values.nginx.config.default }}
+    worker_processes auto;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        upstream php-handler {
+            server 127.0.0.1:9000;
+        }
+
+        server {
+            listen 80;
+
+            # Add headers to serve security related headers
+            # Before enabling Strict-Transport-Security headers please read into this
+            # topic first.
+            #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+            #
+            # WARNING: Only add the preload option once you read about
+            # the consequences in https://hstspreload.org/. This option
+            # will add the domain to a hardcoded list that is shipped
+            # in all major browsers and getting removed from this list
+            # could take several months.
+            add_header Referrer-Policy "no-referrer" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-Download-Options "noopen" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Permitted-Cross-Domain-Policies "none" always;
+            add_header X-Robots-Tag "none" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+
+            # Remove X-Powered-By, which is an information leak
+            fastcgi_hide_header X-Powered-By;
+
+            # Path to the root of your installation
+            root /var/www/html;
+
+            location = /robots.txt {
+                allow all;
+                log_not_found off;
+                access_log off;
+            }
+
+            # The following 2 rules are only needed for the user_webfinger app.
+            # Uncomment it if you're planning to use this app.
+            #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+            #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
+
+            # The following rule is only needed for the Social app.
+            # Uncomment it if you're planning to use this app.
+            #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
+
+            location = /.well-known/carddav {
+                return 301 $scheme://$host:$server_port/remote.php/dav;
+            }
+
+            location = /.well-known/caldav {
+                return 301 $scheme://$host:$server_port/remote.php/dav;
+            }
+
+            # set max upload size
+            client_max_body_size 10G;
+            fastcgi_buffers 64 4K;
+
+            # Enable gzip but do not remove ETag headers
+            gzip on;
+            gzip_vary on;
+            gzip_comp_level 4;
+            gzip_min_length 256;
+            gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+            gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+
+            # Uncomment if your server is build with the ngx_pagespeed module
+            # This module is currently not supported.
+            #pagespeed off;
+
+            location / {
+                rewrite ^ /index.php;
+            }
+
+            location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
+                deny all;
+            }
+            location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
+                deny all;
+            }
+
+            location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
+                fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+                set $path_info $fastcgi_path_info;
+                try_files $fastcgi_script_name =404;
+                include fastcgi_params;
+                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                fastcgi_param PATH_INFO $path_info;
+                # fastcgi_param HTTPS on;
+
+                # Avoid sending the security headers twice
+                fastcgi_param modHeadersAvailable true;
+
+                # Enable pretty urls
+                fastcgi_param front_controller_active true;
+                fastcgi_pass php-handler;
+                fastcgi_intercept_errors on;
+                fastcgi_request_buffering off;
+            }
+
+            location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
+                try_files $uri/ =404;
+                index index.php;
+            }
+
+            # Adding the cache control header for js, css and map files
+            # Make sure it is BELOW the PHP block
+            location ~ \.(?:css|js|woff2?|svg|gif|map)$ {
+                try_files $uri /index.php$request_uri;
+                add_header Cache-Control "public, max-age=15778463";
+                # Add headers to serve security related headers (It is intended to
+                # have those duplicated to the ones above)
+                # Before enabling Strict-Transport-Security headers please read into
+                # this topic first.
+                #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+                #
+                # WARNING: Only add the preload option once you read about
+                # the consequences in https://hstspreload.org/. This option
+                # will add the domain to a hardcoded list that is shipped
+                # in all major browsers and getting removed from this list
+                # could take several months.
+                add_header Referrer-Policy "no-referrer" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-Download-Options "noopen" always;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-Permitted-Cross-Domain-Policies "none" always;
+                add_header X-Robots-Tag "none" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+
+                # Optional: Don't log access to assets
+                access_log off;
+            }
+
+            location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+                try_files $uri /index.php$request_uri;
+                # Optional: Don't log access to other assets
+                access_log off;
+            }
+        }
+    }
+{{- else }}
+{{ .Values.nginx.config.custom | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/php-config.yaml
+++ b/charts/nextcloud/templates/php-config.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.nextcloud.phpConfigs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-phpconfig
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.nextcloud.phpConfigs }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  nextcloud-username: {{ .Values.nextcloud.username | b64enc | quote }}
+  {{ if .Values.nextcloud.password }}
+  nextcloud-password: {{ .Values.nextcloud.password | b64enc | quote }}
+  {{ else }}
+  nextcloud-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  {{- if .Values.nextcloud.mail.enabled }}
+  smtp-username: {{ default "" .Values.nextcloud.mail.smtp.name | b64enc | quote }}
+  smtp-password: {{ default "" .Values.nextcloud.mail.smtp.password | b64enc | quote }}
+  {{- end }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ default "" .Values.service.nodePort}}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}

--- a/charts/nextcloud/values-mariadb.yaml
+++ b/charts/nextcloud/values-mariadb.yaml
@@ -1,0 +1,5 @@
+internalDatabase:
+  enabled: false
+
+mariadb:
+  enabled: true

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -1,0 +1,383 @@
+## Official nextcloud image version
+## ref: https://hub.docker.com/r/library/nextcloud/tags/
+##
+image:
+  repository: nextcloud
+  tag: 17.0.0-apache
+  pullPolicy: IfNotPresent
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Number of replicas to be deployed
+replicaCount: 1
+
+## Allowing use of ingress controllers
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  enabled: false
+  annotations: {}
+  #  nginx.ingress.kubernetes.io/proxy-body-size: 4G
+  #  kubernetes.io/tls-acme: "true"
+  #  certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+  #  nginx.ingress.kubernetes.io/server-snippet: |-
+  #    server_tokens off;
+  #    proxy_hide_header X-Powered-By;
+
+  #    rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
+  #    rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+  #    rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json;
+  #    location = /.well-known/carddav {
+  #      return 301 $scheme://$host/remote.php/dav;
+  #    }
+  #    location = /.well-known/caldav {
+  #      return 301 $scheme://$host/remote.php/dav;
+  #    }
+  #    location = /robots.txt {
+  #      allow all;
+  #      log_not_found off;
+  #      access_log off;
+  #    }
+  #    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+  #      deny all;
+  #    }
+  #    location ~ ^/(?:autotest|occ|issue|indie|db_|console) {
+  #      deny all;
+  #    }
+  #  tls:
+  #    - secretName: nextcloud-tls
+  #      hosts:
+  #        - nextcloud.kube.home
+  labels: {}
+
+
+# Allow configuration of lifecycle hooks
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+lifecycle: {}
+  # postStartCommand: []
+  # preStopCommand: []
+
+nextcloud:
+  host: nextcloud.kube.home
+  username: admin
+  password: changeme
+  update: 0
+  datadir: /var/www/html/data
+  tableprefix:
+  persistence:
+    subPath:
+  mail:
+    enabled: false
+    fromAddress: user
+    domain: domain.com
+    smtp:
+      host: domain.com
+      secure: ssl
+      port: 465
+      authtype: LOGIN
+      name: user
+      password: pass
+  # PHP Configuration files
+  # Will be injected in /usr/local/etc/php/conf.d
+  phpConfigs: {}
+  # Default config files
+  # IMPORTANT: Will be used only if you put extra configs, otherwise default will come from nextcloud itself
+  # Default confgurations can be found here: https://github.com/nextcloud/docker/tree/master/16.0/apache/config
+  defaultConfigs:
+    # To protect /var/www/html/config
+    .htaccess: true
+    # Redis default configuration
+    redis.config.php: true
+    # Apache configuration for rewrite urls
+    apache-pretty-urls.config.php: true
+    # Define APCu as local cache
+    apcu.config.php: true
+    # Apps directory configs
+    apps.config.php: true
+    # Used for auto configure database
+    autoconfig.php: true
+    # SMTP default configuration
+    smtp.config.php: true
+  # Extra config files created in /var/www/html/config/
+  # ref: https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
+  configs: {}
+
+  # For example, to use S3 as primary storage
+  # ref: https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3
+  #
+  #  configs:
+  #    s3.config.php: |-
+  #      <?php
+  #      $CONFIG = array (
+  #        'objectstore' => array(
+  #          'class' => '\\OC\\Files\\ObjectStore\\S3',
+  #          'arguments' => array(
+  #            'bucket'     => 'my-bucket',
+  #            'autocreate' => true,
+  #            'key'        => 'xxx',
+  #            'secret'     => 'xxx',
+  #            'region'     => 'us-east-1',
+  #            'use_ssl'    => true
+  #          )
+  #        )
+  #      );
+
+  ## Strategy used to replace old pods
+  ## IMPORTANT: use with care, it is suggested to leave as that for upgrade purposes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy:
+    type: Recreate
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 1
+    #   maxUnavailable: 0
+
+  ##
+  ## Extra environment variables
+  extraEnv:
+  #  - name: SOME_SECRET_ENV
+  #    valueFrom:
+  #      secretKeyRef:
+  #        name: nextcloud
+  #        key: secret_key
+
+  # Extra mounts for the pods. Example shown is for connecting a legacy NFS volume
+  # to NextCloud pods in Kubernetes. This can then be configured in External Storage
+  extraVolumes:
+  #  - name: nfs
+  #    nfs:
+  #      server: "10.0.0.1"
+  #      path: "/nextcloud_data"
+  #      readOnly: false
+  extraVolumeMounts:
+  #  - name: nfs
+  #    mountPath: "/legacy_data"
+
+nginx:
+  ## You need to set an fpm version of the image for nextcloud if you want to use nginx!
+  enabled: false
+  image:
+    repository: nginx
+    tag: alpine
+    pullPolicy: IfNotPresent
+
+  config:
+    # This generates the default nginx config as per the nextcloud documentation
+    default: true
+    # custom: |-
+    #     worker_processes  1;..
+
+  resources: {}
+
+internalDatabase:
+  enabled: true
+  name: nextcloud
+
+##
+## External database configuration
+##
+externalDatabase:
+  enabled: false
+
+  ## Supported database engines: mysql or postgresql
+  type: mysql
+
+  ## Database host
+  host:
+
+  ## Database user
+  user: nextcloud
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: nextcloud
+
+  ## Use a existing secret
+  existingSecret:
+    enabled: false
+    # secretName: nameofsecret
+    # usernameKey: username
+    # passwordKey: password
+
+##
+## MariaDB chart configuration
+##
+mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: false
+
+  db:
+    name: nextcloud
+    user: nextcloud
+    password: changeme
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
+redis:
+  enabled: false
+  usePassword: false
+
+## Cronjob to execute Nextcloud background tasks
+## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron-jobs
+##
+cronjob:
+  enabled: false
+  # Nexcloud image is used as default but only curl is needed
+  image: {}
+    # repository: nextcloud
+    # tag: 16.0.3-apache
+    # pullPolicy: IfNotPresent
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+  # Every 15 minutes
+  # Note: Setting this to any any other value than 15 minutes might
+  #  cause issues with how nextcloud background jobs are executed
+  schedule: "*/15 * * * *"
+  annotations: {}
+  # Set curl's insecure option if you use e.g. self-signed certificates
+  curlInsecure: false
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 2
+  # If not set, nextcloud deployment one will be set
+  # resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  # If not set, nextcloud deployment one will be set
+  # nodeSelector: {}
+
+  # If not set, nextcloud deployment one will be set
+  # tolerations: []
+
+  # If not set, nextcloud deployment one will be set
+  # affinity: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  loadBalancerIP: nil
+  nodePort: nil
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  # Nextcloud Data (/var/www/html)
+  enabled: false
+  annotations: {}
+  ## nextcloud data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## Liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+## Enable pod autoscaling using HorizontalPodAutoscaler
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+##
+hpa:
+  enabled: false
+  cputhreshold: 60
+  minPods: 1
+  maxPods: 10
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+
+  replicaCount: 1
+  # The metrics exporter needs to know how you serve Nextcloud either http or https
+  https: false
+  timeout: 5s
+
+  image:
+    repository: xperimental/nextcloud-exporter
+    tag: v0.3.0
+    pullPolicy: IfNotPresent
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+
+  ## Metrics exporter pod Annotation and Labels
+  # podAnnotations: {}
+
+  # podLabels: {}
+
+  service:
+    type: ClusterIP
+    ## Use serviceLoadBalancerIP to request a specific static IP,
+    ## otherwise leave blank
+    # loadBalancerIP:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9205"
+    labels: {}

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,6 @@
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
+chart-repos:
+  - stable=https://kubernetes-charts.storage.googleapis.com/
+

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,3 @@
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
This is an import of the nextcloud chart with not material changes,
except for necessary changes from `stable/nextcloud` to the new helm
repo location of `nextcloud/helm` and associated github pages URL.

This also bumps the chart version to 2.0.0 in order to properly sort
this chart ahead of the (soon to be deprecated) stable/nextcloud chart.

Will wait to make this a real PR until #1 is merged.