### PR TITLE
bump chart to validate actions

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 2.0.1
+version: 2.0.2
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:


### PR DESCRIPTION
There have been issues with misnamed 'gh pages' branch causing the chart releaser action to not properly complete. Bumping an end-to-end workflow of this chart to ensure that it all works as expected.