### PR TITLE
[nextcloud] initial move to bitnami dependent charts and add postgres

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: nextcloud
-version: 2.0.2
+version: 2.1.0
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -21,3 +21,16 @@ maintainers:
   email: christian.ingenhaag@googlemail.com
 - name: billimek
   email: jeff@billimek.com
+dependencies:
+- name: postgresql
+  version: 9.1.2
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled
+- name: mariadb
+  version: 7.7.1
+  repository: https://charts.bitnami.com/bitnami
+  condition: mariadb.enabled
+- name: redis
+  version: 10.7.17
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled

--- a/charts/nextcloud/requirements.lock
+++ b/charts/nextcloud/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.1.0
-- name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 10.0.1
-digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
-generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/charts/nextcloud/requirements.yaml
+++ b/charts/nextcloud/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  version: ~7.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: mariadb.enabled
-- name: redis
-  version: ~10.0.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: redis.enabled

--- a/charts/nextcloud/values-mariadb.yaml
+++ b/charts/nextcloud/values-mariadb.yaml
@@ -1,5 +1,0 @@
-internalDatabase:
-  enabled: false
-
-mariadb:
-  enabled: true

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -216,13 +216,29 @@ mariadb:
     user: nextcloud
     password: changeme
 
+  replication:
+    enabled: false
+
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
+  master:
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessMode: ReadWriteOnce
+      size: 8Gi
+
+postgresql:
+  enabled: false
+  global:
+    postgresql:
+      postgresqlUsername: nextcloud
+      postgresqlPassword: changeme
+      postgresqlDatabase: nextcloud
   persistence:
     enabled: false
-    accessMode: ReadWriteOnce
-    size: 8Gi
+    # storageClass: ""
 
 redis:
   enabled: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,4 +3,4 @@ chart-dirs:
   - charts
 chart-repos:
   - stable=https://kubernetes-charts.storage.googleapis.com/
-
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Works fine with mariadb. I haven't been able to test postgres or redis.

Signed-off-by: Ryan Holt <ryan@ryanholt.net>