### PR TITLE
Fix matchLabels to include metrics

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.1.1
+version: 2.1.2
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "nextcloud.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: metrics
   template:
     metadata:
       annotations: {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}


### PR DESCRIPTION
Found this while enabling metric scraping on Rancher as this will otherwise also match the nextcloud deployment 