### PR TITLE
Upgrade to latest version and fix cron

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 2.1.2
-appVersion: 17.0.0
+version: 2.2.0
+appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud
@@ -23,14 +23,14 @@ maintainers:
   email: jeff@billimek.com
 dependencies:
 - name: postgresql
-  version: 9.1.2
+  version: 9.7.2
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: mariadb
-  version: 7.7.1
+  version: 7.10.2
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
 - name: redis
-  version: 10.7.17
+  version: 11.0.5
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -117,6 +117,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                     |
 | `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                              |
 | `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                          |
+| `cronjob.curlInsecure`                                       | Set insecure (-k) option to curl                        | false                                       |
 | `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep               | `5`                                         |
 | `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep            | `2`                                         |
 | `cronjob.resources`                                          | Cronjob Resources                                       | `nil`                                       |

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "nextcloud.fullname" . }}
+  name: {{ template "nextcloud.fullname" . }}-cron
   labels:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}
     helm.sh/chart: {{ include "nextcloud.chart" . }}
@@ -44,9 +44,20 @@ spec:
               imagePullPolicy: {{ default .Values.image.pullPolicy .Values.cronjob.image.pullPolicy }}
               command: [ "curl" ]
               args:
+              {{- if .Values.ingress.enabled }}
+              {{- if .Values.cronjob.curlInsecure }}
+                - "-k"
+              {{- end }}
                 - "--fail"
                 - "-L"
+              {{- if .Values.ingress.tls }}
+                - "https://{{ .Values.nextcloud.host }}/cron.php"
+              {{- else }}
+                - "http://{{ .Values.nextcloud.host }}/cron.php"
+              {{- end }}
+              {{- else }}
                 - "http://{{ template "nextcloud.fullname" . }}:{{ .Values.service.port }}/cron.php"
+              {{- end }}
               resources:
 {{ toYaml (default .Values.resources .Values.cronjob.resources) | indent 16 }}
     {{- with (default .Values.nodeSelector .Values.cronjob.nodeSelector) }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: nextcloud
-  tag: 17.0.0-apache
+  tag: 19.0.3-apache
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName
@@ -245,7 +245,7 @@ redis:
   usePassword: false
 
 ## Cronjob to execute Nextcloud background tasks
-## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron-jobs
+## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#webcron
 ##
 cronjob:
   enabled: false
@@ -256,11 +256,13 @@ cronjob:
     # pullPolicy: IfNotPresent
     # pullSecrets:
     #   - myRegistrKeySecretName
-  # Every 15 minutes
-  # Note: Setting this to any any other value than 15 minutes might
+  # Every 5 minutes
+  # Note: Setting this to any any other value than 5 minutes might
   #  cause issues with how nextcloud background jobs are executed
-  schedule: "*/15 * * * *"
+  schedule: "*/5 * * * *"
   annotations: {}
+  # Set curl's insecure option if you use e.g. self-signed certificates
+  curlInsecure: false
   failedJobsHistoryLimit: 5
   successfulJobsHistoryLimit: 2
   # If not set, nextcloud deployment one will be set


### PR DESCRIPTION
- Upgrading app to latest 19.0.3
- Upgrading dependencies versions
- Cron to run every 5 minutes as specified in the [Nextcloud docs](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#background-jobs)
- Partially revert  #17 as there seem to be an issue with `trusted_domains` when trying to call `cron.php` without ingress
```
root@nextcloud-69c99f6d76-x45qc:/var/www/html# curl -I --fail -L http://nextcloud:8080/cron.php
curl: (22) The requested URL returned error: 400 Bad Request
```
