### PR TITLE
Bump PostgreSQL to 9.8.9

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.2.1
+version: 2.3.0
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,7 +23,7 @@ maintainers:
   email: jeff@billimek.com
 dependencies:
 - name: postgresql
-  version: 9.7.2
+  version: 9.8.9
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: mariadb


### PR DESCRIPTION
I use [Velero](https://www.velero.io) to backup my database. The `pg_dump` & `pg_restore` combination I use requires a working user `postgres`. There is a bug in 9.7.2 and few version earlier, that prevent to set a password to `postgres` user.

It had been fixed in latest release https://github.com/bitnami/charts/pull/4123

This uprgade to latest stable PostgreSQL