### PR TITLE
Add option for a custom secret

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.3.2
+version: 2.4.0
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -61,6 +61,10 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.host`                                             | nextcloud host to create application URLs               | `nextcloud.kube.home`                       |
 | `nextcloud.username`                                         | User of the application                                 | `admin`                                     |
 | `nextcloud.password`                                         | Application password                                    | `changeme`                                  |
+| `nextcloud.existingSecret.enabled`                           | Whether to use an existing secret or not                | `false`                                     |
+| `nextcloud.existingSecret.secretName`                        | Name of the existing secret                             | `nil`                                       |
+| `nextcloud.existingSecret.usernameKey`                       | Name of the key that contains the username              | `nil`                                       |
+| `nextcloud.existingSecret.passwordKey`                       | Name of the key that contains the password              | `nil`                                       |
 | `nextcloud.update`                                           | Trigger update if custom command is used                | `0`                                         |
 | `nextcloud.datadir`                                          | nextcloud data dir location                             | `/var/www/html/data`                        |
 | `nextcloud.tableprefix`                                      | nextcloud db table prefix                               | `''`                                        |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -115,13 +115,13 @@ spec:
         - name: NEXTCLOUD_ADMIN_USER
           valueFrom:
             secretKeyRef:
-              name: {{ template "nextcloud.fullname" . }}
-              key: nextcloud-username
+              name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
+              key: {{ .Values.nextcloud.existingSecret.usernameKey | default "nextcloud-username" }}
         - name: NEXTCLOUD_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "nextcloud.fullname" . }}
-              key: nextcloud-password
+              name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
+              key: {{ .Values.nextcloud.existingSecret.passwordKey | default "nextcloud-password" }}
         - name: NEXTCLOUD_TRUSTED_DOMAINS
           value: {{ .Values.nextcloud.host }}
         {{- if ne (int .Values.nextcloud.update) 0 }}

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nextcloud.existingSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,3 +20,4 @@ data:
   smtp-username: {{ default "" .Values.nextcloud.mail.smtp.name | b64enc | quote }}
   smtp-password: {{ default "" .Values.nextcloud.mail.smtp.password | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -64,6 +64,12 @@ nextcloud:
   host: nextcloud.kube.home
   username: admin
   password: changeme
+  ## Use an existing secret
+  existingSecret:
+    enabled: false
+    # secretName: nameofsecret
+    # usernameKey: username
+    # passwordKey: password
   update: 0
   datadir: /var/www/html/data
   tableprefix:


### PR DESCRIPTION
Introducing options nested under `nextcloud.existingSecret` to allow for a deployment that does not contain the secret and instead uses an existing secret.

### Effect of changes

Differences between `nextcloud/helm@master` and `michel-zimmer/helm@custom-secret` for `helm template .`:

#### Default values
_(no differences)_

#### Values containing a custom secret
```diff
diff --git charts/nextcloud/values.yaml charts/nextcloud/values.yaml
index cb3e14e..de5ae1f 100644
--- charts/nextcloud/values.yaml
+++ charts/nextcloud/values.yaml
@@ -66,10 +66,10 @@ nextcloud:
   password: changeme
   ## Use an existing secret
   existingSecret:
-    enabled: false
-    # secretName: nameofsecret
-    # usernameKey: username
-    # passwordKey: password
+    enabled: true
+    secretName: my-secret-name
+    usernameKey: my-username-key
+    passwordKey: my-password-key
   update: 0
   datadir: /var/www/html/data
   tableprefix:
```

```diff
diff --git before-custom-secret.txt after-custom-secret-enabled.txt
index 4c23d09..f7a88f0 100644
--- before-custom-secret.txt
+++ after-custom-secret-enabled.txt
@@ -1,20 +1,4 @@
 ---
-# Source: nextcloud/templates/secrets.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: RELEASE-NAME-nextcloud
-  labels:
-    app.kubernetes.io/name: nextcloud
-    helm.sh/chart: nextcloud-2.3.2
-    app.kubernetes.io/instance: RELEASE-NAME
-    app.kubernetes.io/managed-by: Helm
-type: Opaque
-data:
-  nextcloud-username: "YWRtaW4="
-  
-  nextcloud-password: "Y2hhbmdlbWU="
----
 # Source: nextcloud/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -73,13 +57,13 @@ spec:
         - name: NEXTCLOUD_ADMIN_USER
           valueFrom:
             secretKeyRef:
-              name: RELEASE-NAME-nextcloud
-              key: nextcloud-username
+              name: my-secret-name
+              key: my-username-key
         - name: NEXTCLOUD_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: RELEASE-NAME-nextcloud
-              key: nextcloud-password
+              name: my-secret-name
+              key: my-password-key
         - name: NEXTCLOUD_TRUSTED_DOMAINS
           value: nextcloud.kube.home
         - name: NEXTCLOUD_DATA_DIR
```

Closes #46