### PR TITLE
Set redis default password and ENV REDIS_HOST_PASSWORD

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           ./get_helm.sh
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add stable https://charts.helm.sh/stable
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
         with:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.3.2
+version: 2.3.3
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -114,6 +114,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `mariadb.db.user`                                            | Database user to create                                 | `nextcloud`                                 |
 | `mariadb.rootUser.password`                                  | MariaDB admin password                                  | `nil`                                       |
 | `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                     |
+| `redis.usePassword`                                          | Whether to use a password with redis                    | `false`                                     |
+| `redis.password`                                             | The password redis uses                                 | `''`                                        |
 | `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                     |
 | `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                              |
 | `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                          |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -163,6 +163,8 @@ spec:
           value: {{ template "nextcloud.redis.fullname" . }}-master
         - name: REDIS_HOST_PORT
           value: {{ .Values.redis.redisPort | quote }}
+        - name: REDIS_HOST_PASSWORD
+          value: {{ .Values.redis.password }}
         {{- end }}
         {{- if .Values.nextcloud.extraEnv }}
 {{ toYaml .Values.nextcloud.extraEnv | indent 8 }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -243,6 +243,7 @@ postgresql:
 redis:
   enabled: false
   usePassword: false
+  password: ''
 
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#webcron


### PR DESCRIPTION
The nextcloud deployment needs the ENV variable `REDIS_HOST_PASSWORD` set in order for authenticated redis to not have issues.  This should fix #29

See https://github.com/nextcloud/docker/pull/1232 for additional details