### PR TITLE
Added initContainer to fix mariadb initial connection failing

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.0
+version: 2.5.4
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.4
+version: 2.5.5
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -332,6 +332,15 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.mariadb.enabled }}
+      initContainers:
+      - name: mariadb-isalive
+        image: bitnami/mariadb
+        command:
+          - "sh"
+          - "-c"
+          - {{ printf "until mysql --host=%s-mariadb --user=%s --password=%s --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name .Values.mariadb.db.user .Values.mariadb.db.password }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This is to fix #60. I'm running this fork in prod now. a similar initcontainer could be added for postgress in the same way. More of an idea than anything, if there's anything you want me to change, or you want to take this and improve it to fit your needs that's fine.