### PR TITLE
fixes nextcloud/helm#70 saving phpConfigs files to the right directory when using fpm

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.1
+version: 2.5.2
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -255,9 +255,10 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- $nginxEnabled := .Values.nginx.enabled -}}
         {{- range $key, $value := .Values.nextcloud.phpConfigs }}
         - name: nextcloud-phpconfig
-          mountPath: /usr/local/etc/php/conf.d/{{ $key }}
+          mountPath: {{ $nginxEnabled | ternary (printf "/usr/local/etc/php-fpm.d/%s" $key | quote) (printf "/usr/local/etc/php/conf.d/%s" $key | quote) }}
           subPath: {{ $key }}
         {{- end }}
         {{- if .Values.nextcloud.extraVolumeMounts }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -89,7 +89,7 @@ nextcloud:
       name: user
       password: pass
   # PHP Configuration files
-  # Will be injected in /usr/local/etc/php/conf.d
+  # Will be injected in /usr/local/etc/php/conf.d for apache image and in /usr/local/etc/php-fpm.d when nginx.enabled: true
   phpConfigs: {}
   # Default config files
   # IMPORTANT: Will be used only if you put extra configs, otherwise default will come from nextcloud itself


### PR DESCRIPTION
- When using nginx + nextcloud fpm image, `phpConfigs` are now mounted to /usr/local/etc/php-fpm.d instead of /usr/local/etc/php/conf.d