### PR TITLE
Fix selector

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.5
+version: 2.5.7
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -23,3 +23,4 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    app.kubernetes.io/component: app


### PR DESCRIPTION
The selector in `service.yaml` accidentally matches not only to the nextcloud pods, but also on cron and metrics:
```
kubectl get pods -l app.kubernetes.io/name=nextcloud
NAME                                 READY   STATUS      RESTARTS   AGE
nextcloud-65d4c48fd9-nxv7d           1/1     Running     0          12m
nextcloud-cron-1613603100-rf6cw      0/1     Completed   0          4m6s
nextcloud-metrics-6fc8bc88b5-86gpx   1/1     Running     0          12m
```
 Adding the `component` label to the selector fixes this:
```
kubectl get pods -l app.kubernetes.io/name=nextcloud,app.kubernetes.io/component=app
NAME                         READY   STATUS    RESTARTS   AGE
nextcloud-65d4c48fd9-nxv7d   1/1     Running   0          13m
```

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).