### PR TITLE
Use external secrets for mariadb-isalive if available.

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.5
+version: 2.5.6
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `internalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
 | `externalDatabase.enabled`                                   | Whether to use external database                        | `false`                                     |
 | `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`           | `mysql`                                     |
-| `externalDatabase.host`                                      | Host of the external database                           | `nil`                                       |
+| `externalDatabase.host`                                      | Host of the external database in form of `host:port`    | `nil`                                       |
 | `externalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
 | `externalDatabase.user`                                      | Existing username in the external db                    | `nextcloud`                                 |
 | `externalDatabase.password`                                  | Password for the above username                         | `nil`                                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -337,10 +337,21 @@ spec:
       initContainers:
       - name: mariadb-isalive
         image: bitnami/mariadb
+        env:
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+                key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+                key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
         command:
           - "sh"
           - "-c"
-          - {{ printf "until mysql --host=%s-mariadb --user=%s --password=%s --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name .Values.mariadb.db.user .Values.mariadb.db.password }}
+          - {{ printf "until mysql --host=%s-mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name }}
       {{- end }}
     {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
# Pull Request

## Description of the change
Adds logic to use either credentials directly provided via helm chart or secrets referenced by in a k8s-secret for mariadb-isalive init pod.

## Benefits

Fixes #80 

## Possible drawbacks
I hope none.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #80

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
