### PR TITLE
redis / postgresql improvements

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.8
+version: 2.5.9
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/config.yaml
+++ b/charts/nextcloud/templates/config.yaml
@@ -39,6 +39,7 @@ data:
         'redis' => array(
           'host' => getenv('REDIS_HOST'),
           'port' => getenv('REDIS_HOST_PORT') ?: 6379,
+          'password' => getenv('REDIS_HOST_PASSWORD'),
         ),
       );
     }

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -163,8 +163,16 @@ spec:
           value: {{ template "nextcloud.redis.fullname" . }}-master
         - name: REDIS_HOST_PORT
           value: {{ .Values.redis.redisPort | quote }}
+        {{- if and .Values.redis.existingSecret .Values.redis.existingSecretPasswordKey }}
+        - name: REDIS_HOST_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.existingSecret }}
+              key: {{ .Values.redis.existingSecretKey }}
+        {{- else }}
         - name: REDIS_HOST_PASSWORD
           value: {{ .Values.redis.password }}
+        {{- end }}
         {{- end }}
         {{- if .Values.nextcloud.extraEnv }}
 {{ toYaml .Values.nextcloud.extraEnv | indent 8 }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -360,6 +360,20 @@ spec:
           - "sh"
           - "-c"
           - {{ printf "until mysql --host=%s-mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name }}
+      {{- else if .Values.postgresql.enabled }}
+      initContainers:
+      - name: postgresql-isready
+        image: bitnami/postgresql
+        env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+                key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+        command:
+          - "sh"
+          - "-c"
+          - {{ printf "until pg_isready -h %s-postgresql -U ${POSTGRES_USER} ; do sleep 2 ; done" .Release.Name }}
       {{- end }}
     {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
# Pull Request

## Description of the change

* Adds an `initContainer` which uses `pg_isready` to postpone installation attempts
* Makes proper use of redis passwords, including `redis.existingSecret` from the dependent chart

## Benefits

* Better integration with redis and postgresql dependencies

## Applicable issues

- fixes #42

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
