### PR TITLE
Fix default redis config

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.9
+version: 2.5.10
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -250,8 +250,8 @@ postgresql:
 
 redis:
   enabled: false
-  usePassword: false
-  password: ''
+  usePassword: true
+  password: 'changeme'
 
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#webcron


### PR DESCRIPTION
# Pull Request

## Description of the change
Even with an empty password, nextcloud tries to AUTH with redis-6, which results in mysterious 303 when trying to log in

<!-- Describe the scope of your change - i.e. what the change does. -->

## Benefits
Redis works with the default config
<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #66 

## Additional information
This is what happens if the password is not set, but auth is disabled on redis side. Deleting the line
```
'password' => getenv('REDIS_HOST_PASSWORD'),
```
in redis.config.php doesn't help
<img width="1603" alt="Screenshot 2021-02-24 at 20 03 00" src="https://user-images.githubusercontent.com/50323052/109053648-3bea6880-76dd-11eb-8b7d-d84f7bbebaa8.png">

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
