### PR TITLE
render ingress according to supported apiVersion

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.11
+version: 2.5.12
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.12
+version: 2.5.13
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -47,3 +47,13 @@ Create chart name and version as used by the chart label.
 {{- define "nextcloud.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "nextcloud.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- end -}}

--- a/charts/nextcloud/templates/ingress.yaml
+++ b/charts/nextcloud/templates/ingress.yaml
@@ -22,11 +22,11 @@ spec:
     http:
       paths:
       - path: /
-        {{- if eq (include "transmission.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+        {{- if eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1" }}
         pathType: Prefix
         {{- end }}
         backend:
-          {{- if eq (include "transmission.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+          {{- if eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1" }}
           service:
             name: {{ template "nextcloud.fullname" . }}
             port:

--- a/charts/nextcloud/templates/ingress.yaml
+++ b/charts/nextcloud/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "nextcloud.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "nextcloud.fullname" . }}
@@ -21,9 +21,20 @@ spec:
   - host: {{ .Values.nextcloud.host }}
     http:
       paths:
-      - backend:
+      - path: /
+        {{- if eq (include "transmission.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
+        backend:
+          {{- if eq (include "transmission.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+          service:
+            name: {{ template "nextcloud.fullname" . }}
+            port:
+              number: {{ .Values.service.port }}
+          {{- else }}
           serviceName: {{ template "nextcloud.fullname" . }}
           servicePort: {{ .Values.service.port }}
+          {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}


### PR DESCRIPTION
# Pull Request

## Description of the change
Renders the ingress resource according to newest supported apiVersion
<!-- Describe the scope of your change - i.e. what the change does. -->

## Benefits
networking.k8s.io/v1beta1 is going away soon. This also lays the groundwork for supporting High Performance Back-end in NC21
<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
