### PR TITLE
fix: remove trailing colon in cronjob.yaml

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.14
+version: 2.5.15
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -70,6 +70,6 @@ spec:
     {{- end }}
     {{- with (default .Values.tolerations .Values.cronjob.tolerations) }}
           tolerations:
-{{ toYaml . | indent 12 }}:
+{{ toYaml . | indent 12 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes YAML parse error on nextcloud/templates/cronjob.yaml when setting tolerations

# Pull Request

## Description of the change

Removes a `:` causing the following error when using `tolerations` in values.

Full error :
```
Error: UPGRADE FAILED: YAML parse error on nextcloud/templates/cronjob.yaml: error converting YAML to JSON: yaml: line 45: mapping values are not allowed in this context
```

## Benefits

Makes `tolerations` usable. 

## Possible drawbacks

None

## Applicable issues

None

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
