### PR TITLE
change initcontainers image and tag to follow subchart, disable startupProbe with nginx

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.5.15
+version: 2.5.16
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -340,7 +340,7 @@ spec:
       {{- if .Values.mariadb.enabled }}
       initContainers:
       - name: mariadb-isalive
-        image: bitnami/mariadb
+        image: {{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
         env:
           - name: MYSQL_USER
             valueFrom:
@@ -359,7 +359,7 @@ spec:
       {{- else if .Values.postgresql.enabled }}
       initContainers:
       - name: postgresql-isready
-        image: bitnami/postgresql
+        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
         env:
           - name: POSTGRES_USER
             valueFrom:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -207,7 +207,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
-        {{- if .Values.startupProbe.enabled }}
+        {{- if and .Values.startupProbe.enabled (not .Values.nginx.enabled) }}
         startupProbe:
           httpGet:
             path: /status.php


### PR DESCRIPTION
# Pull Request

## Description of the change

mariadb-isalive and postgresql-isready init containers now take their image name and tag from the postgres and mariadb sub charts.

## Benefits

you can now use this chart on a raspberrypi if you set the db images to the default (postgres:version)
also disabled the startupProbe if the chart is used with nginx configuration (as with the other probes)

## Possible drawbacks


## Applicable issues


- fixes #99 
- fixes #94 
- fixes #61 

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
