### PR TITLE
Fix redis password secret key ref

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.6.0
+version: 2.6.1
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -164,7 +164,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ .Values.redis.existingSecret }}
-              key: {{ .Values.redis.existingSecretKey }}
+              key: {{ .Values.redis.existingSecretPasswordKey }}
         {{- else }}
         - name: REDIS_HOST_PASSWORD
           value: {{ .Values.redis.password }}


### PR DESCRIPTION
# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
There is an inconsistency in the deployment.yaml now when specifying a redis password via secret. 

The template checks for `.Values.redis.existingSecretPasswordKey` to exist and then uses `.Values.redis.existingSecretKey` as the value instead. Looking at the Bitnami Redis chart specified in the dependencies, `existingSecretPasswordKey` is the correct name.

```
        {{- if and .Values.redis.existingSecret .Values.redis.existingSecretPasswordKey }}
        - name: REDIS_HOST_PASSWORD
          valueFrom:
            secretKeyRef:
              name: {{ .Values.redis.existingSecret }}
              key: {{ .Values.redis.existingSecretKey }} <--- does not match above
        {{- else }}
```

## Benefits

<!-- What benefits will be realized by the code change? -->
Fixes a minor bug.

## Possible drawbacks

<!-- Describe any known limitations with your change -->
None. Since the user must be specifying `.Values.redis.existingSecretPasswordKey` today to get this to work, even if a workaround is in place (specifying both keys), there should be no impact to currently deployed charts.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
