### PR TITLE
Added possibility to use priviledged PSP

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.6.1
+version: 2.6.2
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -141,6 +141,9 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                    | `ReadWriteOnce`                             |
 | `persistence.size`                                           | PVC Storage Request for nextcloud volume                | `8Gi`                                       |
 | `resources`                                                  | CPU/Memory resource requests/limits                     | `{}`                                        |
+| `rbac.enabled`                                               | Enable Role and rolebinding for priveledged PSP         | `false`                                     |
+| `rbac.serviceaccount.create`                                 | Wether to create a serviceaccount or use an existing one (requires rbac) | `true`                     |
+| `rbac.serviceaccount.name`                                   | The name of the sevice account that the deployment will use (requires rbac) | `nextcloud-serviceaccount` |
 | `livenessProbe.enabled`                                      | Turn on and off liveness probe                          | `true`                                      |
 | `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                | `10`                                        |
 | `livenessProbe.periodSeconds`                                | How often to perform the probe                          | `10`                                        |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -414,3 +414,6 @@ spec:
       securityContext:
         fsGroup: 33
       {{- end }}
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
+      {{- end }}

--- a/charts/nextcloud/templates/rbac.yaml
+++ b/charts/nextcloud/templates/rbac.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-privileged
+  namespace: {{ .Release.namespace }}
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-privileged
+  namespace: {{ .Release.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "nextcloud.fullname" . }}-privileged
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.rbac.serviceaccount.name }}
+  namespace: {{ .Release.namespace }}
+{{- end }}

--- a/charts/nextcloud/templates/serviceaccount.yaml
+++ b/charts/nextcloud/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+{{- if and .Values.rbac.enabled .Values.rbac.serviceaccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceaccount.name }}
+{{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -415,3 +415,9 @@ metrics:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9205"
     labels: {}
+
+rbac:
+  enabled: false
+  serviceaccount:
+    create: true
+    name: nextcloud-serviceaccount


### PR DESCRIPTION
# Pull Request

## Description of the change

Gives you the possibility to create a service account for the deployment and RBAC to bind it to the priviledged PSP.

## Benefits

If you want to deploy this to a cluster that has PSP enabled, this makes it possible

## Possible drawbacks

Since it's an opt-in option this shouldn't affect any running or new deployments as long as you don't activate it.

## Applicable issues

Until #9 is closed, this is one way of getting the deployment up and running on clusters with PSP enabled

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
