### PR TITLE
Use service account name also for cronjob

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.6.4
+version: 2.6.5
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -77,6 +77,9 @@ spec:
               {{- end }}
               resources:
 {{ toYaml (default .Values.resources .Values.cronjob.resources) | indent 16 }}
+          {{- if .Values.rbac.enabled }}
+          serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
+          {{- end }}
     {{- with (default .Values.nodeSelector .Values.cronjob.nodeSelector) }}
           nodeSelector:
 {{ toYaml . | indent 12 }}


### PR DESCRIPTION
# Pull Request

## Description of the change

When pod security policies (PSP) are used, then the securityContext typically has e.g. a "runAsUser" attribute and a (non-default) service account. The cronjob uses the same security context as the regular deployment, so it should also use the same service account. With PSP enabled, a pod created with the "wrong" service account will not be able to start.

## Benefits

The current chart works with PSP (when security context and service account are set correctly). But when you enable the cronjob, it will not start - this is fixed here.

## Possible drawbacks

Cronjob pod has more permissions than it needs. But this is already the case, it starts "curl" as root by default, which is just not needed. Fixing this would be a breaking change and should be considered in a separate PR.

## Applicable issues

- PSP support: https://github.com/nextcloud/helm/pull/105
- Non-root support: https://github.com/nextcloud/helm/pull/98

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
