### PR TITLE
Use securityContext for deployment and cronjob

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.6.5
+version: 2.6.6
 appVersion: 19.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -63,6 +63,11 @@ spec:
                 {{- with .Values.cronjob.securityContext }}
                 {{- toYaml . | nindent 17 }}
                 {{- end }}
+              {{- else if .Values.securityContext }}
+              securityContext:
+                {{- with .Values.securityContext }}
+                {{- toYaml . | nindent 17 }}
+                {{- end }}
               {{- end }}
               resources:
 {{ toYaml (default .Values.resources .Values.cronjob.resources) | indent 16 }}

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -61,16 +61,16 @@ spec:
               # Will mount configuration files as www-data (id: 82) for nextcloud
               {{- if .Values.nginx.enabled }}
               securityContext:
-                {{- if .Values.securityContext }}
-                {{- with .Values.securityContext }}
+                {{- if .Values.cronjob.securityContext }}
+                {{- with .Values.cronjob.securityContext }}
                 {{- toYaml . | nindent 17 }}
                 {{- end }}
                 {{- end }}
               {{- else }}
               # Will mount configuration files as www-data (id: 33) for nextcloud
               securityContext:
-                {{- if .Values.securityContext }}
-                {{- with .Values.securityContext }}
+                {{- if .Values.cronjob.securityContext }}
+                {{- with .Values.cronjob.securityContext }}
                 {{- toYaml . | nindent 17 }}
                 {{- end }}
                 {{- end }}

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -58,21 +58,10 @@ spec:
               {{- else }}
                 - "http://{{ template "nextcloud.fullname" . }}:{{ .Values.service.port }}/cron.php"
               {{- end }}
-              # Will mount configuration files as www-data (id: 82) for nextcloud
-              {{- if .Values.nginx.enabled }}
+              {{- if .Values.cronjob.securityContext }}
               securityContext:
-                {{- if .Values.cronjob.securityContext }}
                 {{- with .Values.cronjob.securityContext }}
                 {{- toYaml . | nindent 17 }}
-                {{- end }}
-                {{- end }}
-              {{- else }}
-              # Will mount configuration files as www-data (id: 33) for nextcloud
-              securityContext:
-                {{- if .Values.cronjob.securityContext }}
-                {{- with .Values.cronjob.securityContext }}
-                {{- toYaml . | nindent 17 }}
-                {{- end }}
                 {{- end }}
               {{- end }}
               resources:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -412,6 +412,10 @@ spec:
         {{- with .Values.nextcloud.securityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- else if .Values.securityContext }}
+        {{- with .Values.securityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- else }}
         fsGroup: 82
         {{- end }}
@@ -420,6 +424,10 @@ spec:
       securityContext:
         {{- if .Values.nextcloud.securityContext }}
         {{- with .Values.nextcloud.securityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- else if .Values.securityContext }}
+        {{- with .Values.securityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- else }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -408,20 +408,22 @@ spec:
       {{- if .Values.nginx.enabled }}
       # Will mount configuration files as www-data (id: 82) for nextcloud
       securityContext:
-        fsGroup: 82
-        {{- if .Values.securityContext }}
-        {{- with .Values.securityContext }}
+        {{- if .Values.nextcloud.securityContext }}
+        {{- with .Values.nextcloud.securityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- else }}
+        fsGroup: 82
         {{- end }}
       {{- else }}
       # Will mount configuration files as www-data (id: 33) for nextcloud
       securityContext:
-        fsGroup: 33
-        {{- if .Values.securityContext }}
-        {{- with .Values.securityContext }}
+        {{- if .Values.nextcloud.securityContext }}
+        {{- with .Values.nextcloud.securityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- else }}
+        fsGroup: 33
         {{- end }}
       {{- end }}
       {{- if .Values.rbac.enabled }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -165,8 +165,8 @@ nextcloud:
   #  - name: nfs
   #    mountPath: "/legacy_data"
 
-  # Extra secuurityContext parameters. For example you may need to define runAsNonRoot directive
-  # extraSecurityContext:
+  # securityContext parameters. For example you may need to define runAsNonRoot directive
+  # securityContext:
   #   runAsUser: "33"
   #   runAsGroup: "33"
   #   runAsNonRoot: true
@@ -305,6 +305,13 @@ cronjob:
 
   # If not set, nextcloud deployment one will be set
   # affinity: {}
+
+  # securityContext parameters. For example you may need to define runAsNonRoot directive
+  # securityContext:
+  #   runAsUser: "33"
+  #   runAsGroup: "33"
+  #   runAsNonRoot: true
+  #   readOnlyRootFilesystem: true
 
 service:
   type: ClusterIP

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -313,6 +313,14 @@ cronjob:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
+# @deprecated nextcloud.securityContext and cronjob.securityContext should be used.
+# securityContext parameters. For example you may need to define runAsNonRoot directive
+# securityContext:
+#   runAsUser: "33"
+#   runAsGroup: "33"
+#   runAsNonRoot: true
+#   readOnlyRootFilesystem: true
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
# Pull Request

## Description of the change

Do a separation of securityContext for deployment and cronjob.

## Benefits

Possibility to set `fsGroup` and `fsGroupChangePolicy` on deployment. 
With the current setup, `fsGroup` and `fsGroupChangePolicy` cannot be set because cronjob and deployment uses the same securityContext and cronjob securityContext doesn't have `fsGroup` field.

## Possible drawbacks

This PR should backward compatible.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
