### PR TITLE
fix duplicate key and wrong var name in templates

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.8.2
+version: 2.8.3
 appVersion: 21.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -433,12 +433,3 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
       {{- end }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
-      {{- end }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
-      {{- end }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
-      {{- end }}

--- a/charts/nextcloud/templates/rbac.yaml
+++ b/charts/nextcloud/templates/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "nextcloud.fullname" . }}-privileged
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - extensions
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "nextcloud.fullname" . }}-privileged
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -26,5 +26,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.rbac.serviceaccount.name }}
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Duplicate `serviceAccountName` key makes it impossible to use `kubectl kustomize` as a helm post-renderer hook.

This is because two templated YAMLs are not valid, so that `kustomize` cannot unmarshal them into kubernetes Go structs.

The duplicate key was removed from deployment spec.

Also, the namespace reference ` .Release.Namespace` was fixed in `rbac.yaml` because it is case sensitive.

IMHO, it might be a good idea to test validity of the rendered YAMLs in [the lint and/or release pipleline](https://github.com/nextcloud/helm/tree/master/.github/workflows). HDYT?


## How to test

```bash
kubectl version
# A GitVersion:"v1.21.0" or newer is required, because the older versions have very old kustomize, see https://github.com/kubernetes-sigs/kustomize

cd $pathToGitRepo
git checkout fix-deployment
mkdir kustomize

cat <<'EOF' > ./kustomize/kustomize.sh
#!/bin/bash
cat <&0 > "$(dirname $0)/all.yaml"
kubectl kustomize ./kustomize && rm "$(dirname $0)/all.yaml"
EOF
chmod 755 ./kustomize/kustomize.sh

cat <<EOF > ./kustomize/kustomization.yaml
resources:
  - all.yaml
patches:
  - path: deployment.yaml
    target:
      kind: Deployment
      name: "nc-nextcloud"
EOF

cat <<EOF > ./kustomize/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: doesNotMatter
spec:
  template:
    spec:
      containers:
      - name: nextcloud
        volumeMounts:
        - name: apache-config
          mountPath: "/etc/apache2/mods-available/mpm_prefork.conf"
          readOnly: true
          subPath: mpm_prefork.conf
      volumes:
      - name: apache-config
        configMap:
          name: apache-config
EOF

helm dependency update ./charts/nextcloud/
helm template  --post-renderer ./kustomize/kustomize.sh --namespace=nc --create-namespace nc ./charts/nextcloud/ | grep apache-config
# goes well

git checkout master

helm template  --post-renderer ./kustomize/kustomize.sh --namespace=nc --create-namespace --set postgresql.enabled=false,mariadb.enabled=false,redis.enabled=false,rbac.enabled=true nc ./charts/nextcloud/ | grep apache-config
#Error: error while running post render on files: error while running command /home/akabaka/src/github.com/nextcloud/helm/kustomize/kustomize.sh. error output:
#panic: interface conversion: interface {} is nil, not string
#
#goroutine 1 [running]:
#k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/api/resmap.getNamespacesForRoleBinding(0xc0008c75c0, 0xc00202a348)
```

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
