### PR TITLE
Update nextcloud image to 20.0.11

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 2.6.5
-appVersion: 19.0.3
+version: 2.7.0
+appVersion: 20.0.11
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: nextcloud
-  tag: 19.0.3-apache
+  tag: 20.0.11-apache
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName


### PR DESCRIPTION
# Pull Request

## Description of the change

NC 19 is now out of support, update the default image to 20.0.11
## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
