### PR TITLE
Update chart dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 .devcontainer/
 
 # Helm resources
-charts/*/Chart.lock
 charts/*/charts

--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.5.3
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.10.4
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.3.4
+digest: sha256:7141d51e71932e7f417e7132af078de09737e40a100b0fb431c842600fad4196
+generated: "2021-08-04T15:10:09.617017404+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.7.0
+version: 2.7.1
 appVersion: 20.0.11
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
   email: jeff@billimek.com
 dependencies:
 - name: postgresql
-  version: 10.3.7
+  version: 10.5.*
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: mariadb
-  version: 7.10.2
+  version: 7.10.*
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
 - name: redis
-  version: 11.0.5
+  version: 11.3.*
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled


### PR DESCRIPTION
# Pull Request

## Description of the change

This change updates chart dependencies to the next non-breaking release.
It removes the Chart.lock from gitignore, since it's common to commit
this to repositories.


## Benefits

Probably less vulnerabilities in dependencies as they are still pretty outdated.

## Possible drawbacks



## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
