### PR TITLE
Add Dependabot configuration from template repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
Adds Dependabot updates for GitHub Actions.

See: https://github.com/nextcloud/.github/blob/master/.github/dependabot.yml

Example: https://github.com/splitt3r/helm/pull/2

After merging this you will be able to trigger manual checks at https://github.com/nextcloud/helm/network/updates