### PR TITLE
Fix MYSQL_ env variables conditional

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.8.2
+version: 2.8.3
 appVersion: 21.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             secretKeyRef:
               name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
               key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
-          {{- else }}
+          {{- else if eq .Values.externalDatabase.type "mysql" }}
         - name: MYSQL_HOST
           value: {{ .Values.externalDatabase.host | quote }}
         - name: MYSQL_DATABASE


### PR DESCRIPTION
# Pull Request

I want to set all POSTGRES_ values from a mounted secret (even POSTGRES_DB_FILE, POSTGRES_USER_FILE and POSTGRES_PASSWORD_FILE). Therefore I have set:
- internalDatabase.enabled: false
- externalDatabase.type: "" # in order to not have the environment variables set by the deployment.yaml

The `file_env` behaviour of /entrypoint.sh does not support both (POSTGRES_DB and POSTGRES_HOST_FILE), it will `echo >&2 "error: both $var and $fileVar are set (but are exclusive)"`. 

The unfortunate behaviour of the chart as of today is to "fall back" to MYSQL_ variables which in turn will trigger the "mysql" path in the entrypoint.sh. This does not really make sense.

Tried alternatives without this PR:
I can not override/unset POSTGRES_* via extraEnv, because they are already set. I can not override the entrypoint to unset them.

## Description of the change

This PR does not clearly introduce a new configuration capability but somewhat compensates a weird configuration quirk and as a side effect...

## Benefits

...  allows configuring database env variables freely.

## Possible drawbacks

Likely none, `mysql` is the default value for `externalDatabase.type` anyway

## Applicable issues

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
