### PR TITLE
GKE ingress

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.9.0
+version: 2.9.1
 appVersion: 21.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -68,10 +68,10 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.existingSecret.secretName`                        | Name of the existing secret                             | `nil`                                       |
 | `nextcloud.existingSecret.usernameKey`                       | Name of the key that contains the username              | `nil`                                       |
 | `nextcloud.existingSecret.passwordKey`                       | Name of the key that contains the password              | `nil`                                       |
-| `nextcloud.existingSecret.smtpUsernameKey`                       | Name of the key that contains the SMTP username         | `nil`                                       |
-| `nextcloud.existingSecret.smtpPasswordKey`                       | Name of the key that contains the SMTP password         | `nil`                                       |
+| `nextcloud.existingSecret.smtpUsernameKey`                   | Name of the key that contains the SMTP username         | `nil`                                       |
+| `nextcloud.existingSecret.smtpPasswordKey`                   | Name of the key that contains the SMTP password         | `nil`                                       |
 | `nextcloud.update`                                           | Trigger update if custom command is used                | `0`                                         |
-| `nextcloud.containerPort`                                    | Customize container port when not running as root                | `80`                                         |
+| `nextcloud.containerPort`                                    | Customize container port when not running as root       | `80`                                        |
 | `nextcloud.datadir`                                          | nextcloud data dir location                             | `/var/www/html/data`                        |
 | `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                | `false`                                     |
 | `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                          | `nil`                                       |
@@ -86,13 +86,13 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.persistence.subPath`                              | Set the subPath for nextcloud to use in volume          | `nil`                                       |
 | `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d` | `{}`                                        |
 | `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`     | `true`                                      |
-| `nextcloud.defaultConfigs.redis\.config\.php`              | Default Redis configuration                             | `true`                                      |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls           | `true`                                      |
-| `nextcloud.defaultConfigs.apcu\.config\.php`               | Default configuration to define APCu as local cache     | `true`                                      |
-| `nextcloud.defaultConfigs.apps\.config\.php`               | Default configuration for apps                          | `true`                                      |
-| `nextcloud.defaultConfigs.autoconfig\.php`                 | Default auto-configuration for databases                | `true`                                      |
-| `nextcloud.defaultConfigs.smtp\.config\.php`               | Default configuration for smtp                          | `true`                                      |
-| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                                      |
+| `nextcloud.defaultConfigs.redis\.config\.php`                | Default Redis configuration                             | `true`                                      |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`   | Default Apache configuration for rewrite urls           | `true`                                      |
+| `nextcloud.defaultConfigs.apcu\.config\.php`                 | Default configuration to define APCu as local cache     | `true`                                      |
+| `nextcloud.defaultConfigs.apps\.config\.php`                 | Default configuration for apps                          | `true`                                      |
+| `nextcloud.defaultConfigs.autoconfig\.php`                   | Default auto-configuration for databases                | `true`                                      |
+| `nextcloud.defaultConfigs.smtp\.config\.php`                 | Default configuration for smtp                          | `true`                                      |
+| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                        |
 | `nextcloud.extraEnv`                                         | specify additional environment variables                | `{}`                                        |
 | `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod        | `{}`                                        |
 | `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod  | `{}`                                        |
@@ -160,11 +160,11 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `readinessProbe.timeoutSeconds`                              | When the probe times out                                | `5`                                         |
 | `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe              | `3`                                         |
 | `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                         |
-| `startupProbe.enabled`                                       | Turn on and off startup probe                           | `false`                                      |
+| `startupProbe.enabled`                                       | Turn on and off startup probe                           | `false`                                     |
 | `startupProbe.initialDelaySeconds`                           | Delay before readiness probe is initiated               | `30`                                        |
 | `startupProbe.periodSeconds`                                 | How often to perform the probe                          | `10`                                        |
 | `startupProbe.timeoutSeconds`                                | When the probe times out                                | `5`                                         |
-| `startupProbe.failureThreshold`                              | Minimum consecutive failures for the probe              | `30`                                         |
+| `startupProbe.failureThreshold`                              | Minimum consecutive failures for the probe              | `30`                                        |
 | `startupProbe.successThreshold`                              | Minimum consecutive successes for the probe             | `1`                                         |
 | `hpa.enabled`                                                | Boolean to create a HorizontalPodAutoscaler             | `false`                                     |
 | `hpa.cputhreshold`                                           | CPU threshold percent for the HorizontalPodAutoscale    | `60`                                        |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -58,6 +58,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `ingress.servicePort`                                        | Ingress' backend servicePort                            | `http`                                      |
 | `ingress.annotations`                                        | An array of service annotations                         | `nil`                                       |
 | `ingress.labels`                                             | An array of service labels                              | `nil`                                       |
+| `ingress.path`                                               | The `Path` to use in Ingress' `paths`                   | `/`                                         |
+| `ingress.pathType`                                           | The `PathType` to use in Ingress' `paths`               | `Prefix`                                    |
 | `ingress.tls`                                                | Ingress TLS configuration                               | `[]`                                        |
 | `nextcloud.host`                                             | nextcloud host to create application URLs               | `nextcloud.kube.home`                       |
 | `nextcloud.username`                                         | User of the application                                 | `admin`                                     |

--- a/charts/nextcloud/templates/ingress.yaml
+++ b/charts/nextcloud/templates/ingress.yaml
@@ -24,9 +24,9 @@ spec:
   - host: {{ .Values.nextcloud.host }}
     http:
       paths:
-      - path: /
+      - path: {{ .Values.ingress.path }}
         {{- if eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1" }}
-        pathType: Prefix
+        pathType: {{ .Values.ingress.pathType }}
         {{- end }}
         backend:
           {{- if eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1" }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -53,6 +53,8 @@ ingress:
   #     hosts:
   #       - nextcloud.kube.home
   labels: {}
+  path: /
+  pathType: Prefix
 
 
 # Allow configuration of lifecycle hooks


### PR DESCRIPTION
# Pull Request

## Description of the change

Ability to configure for use with a GKE Ingress (on Google Cloud Platform). Before, this was not possible (see #158).

## Benefits

These values can be specified to make Nextcloud work on GKE (with a GKE Ingress):

```yaml
ingress:
  enabled: true
  annotations:
    [...]
    kubernetes.io/ingress.class: gce
    [...]
  path: /*
  pathType: ImplementationSpecific
```

## Possible drawbacks

None. Other users don't have to change anything. Their setup is unaffected by this change.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #158

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
