### PR TITLE
add posibility to have data on a second pvc that can have independent limits, storage class from main pvc

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.9.1
+version: 2.9.2
 appVersion: 21.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -144,6 +144,12 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume               | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                    | `ReadWriteOnce`                             |
 | `persistence.size`                                           | PVC Storage Request for nextcloud volume                | `8Gi`                                       |
+| `persistence.nextcloudData.enabled`                          | Create a second PVC for the data folder in nextcloud    | `false`                                     |
+| `persistence.nextcloudData.annotations`                      | see `persistence.annotations`                           | `{}`                                        |
+| `persistence.nextcloudData.storageClass`                     | see `persistence.storageClass`                          | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.existingClaim`                    | see `persistence.existingClaim`                         | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.accessMode`                       | see `persistence.accessMode`                            | `ReadWriteOnce`                             |
+| `persistence.nextcloudData.size`                             | see `persistence.size`                                  | `8Gi`                                       |
 | `resources`                                                  | CPU/Memory resource requests/limits                     | `{}`                                        |
 | `rbac.enabled`                                               | Enable Role and rolebinding for priveledged PSP         | `false`                                     |
 | `rbac.serviceaccount.create`                                 | Wether to create a serviceaccount or use an existing one (requires rbac) | `true`                     |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -230,25 +230,31 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/
           subPath: {{ ternary "root" (printf "%s/%s" .Values.nextcloud.persistence.subPath "root") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html
           subPath: {{ ternary "html" (printf "%s/%s" .Values.nextcloud.persistence.subPath "html") (empty .Values.nextcloud.persistence.subPath) }}
+        {{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
         - name: nextcloud-data
           mountPath: {{ .Values.nextcloud.datadir }}
-          subPath: {{ ternary "data" (printf "%s/%s" .Values.nextcloud.persistence.subPath "data") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.persistence.nextcloudData.subPath "data") (empty .Values.persistence.nextcloudData.subPath) }}
+        {{- else }}
+        - name: nextcloud-main
+          mountPath: {{ .Values.nextcloud.datadir }}
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.persistence.subPath "data") (empty .Values.persistence.subPath) }}
+        {{- end }}
+        - name: nextcloud-main
           mountPath: /var/www/html/config
           subPath: {{ ternary "config" (printf "%s/%s" .Values.nextcloud.persistence.subPath "config") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html/custom_apps
           subPath: {{ ternary "custom_apps" (printf "%s/%s" .Values.nextcloud.persistence.subPath "custom_apps") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/tmp
           subPath: {{ ternary "tmp" (printf "%s/%s" .Values.nextcloud.persistence.subPath "tmp") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html/themes
           subPath: {{ ternary "themes" (printf "%s/%s" .Values.nextcloud.persistence.subPath "themes") (empty .Values.nextcloud.persistence.subPath) }}
         {{- range $key, $value := .Values.nextcloud.configs }}
@@ -314,25 +320,31 @@ spec:
         resources:
 {{ toYaml .Values.nginx.resources | indent 10 }}
         volumeMounts:
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/
           subPath: {{ ternary "root" (printf "%s/%s" .Values.nextcloud.persistence.subPath "root") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html
           subPath: {{ ternary "html" (printf "%s/%s" .Values.nextcloud.persistence.subPath "html") (empty .Values.nextcloud.persistence.subPath) }}
+        {{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
         - name: nextcloud-data
           mountPath: {{ .Values.nextcloud.datadir }}
-          subPath: {{ ternary "data" (printf "%s/%s" .Values.nextcloud.persistence.subPath "data") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.persistence.nextcloudData.subPath "data") (empty .Values.persistence.nextcloudData.subPath) }}
+        {{- else }}
+        - name: nextcloud-main
+          mountPath: {{ .Values.nextcloud.datadir }}
+          subPath: {{ ternary "data" (printf "%s/%s" .Values.persistence.subPath "data") (empty .Values.persistence.subPath) }}
+        {{- end }}
+        - name: nextcloud-main
           mountPath: /var/www/html/config
           subPath: {{ ternary "config" (printf "%s/%s" .Values.nextcloud.persistence.subPath "config") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html/custom_apps
           subPath: {{ ternary "custom_apps" (printf "%s/%s" .Values.nextcloud.persistence.subPath "custom_apps") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/tmp
           subPath: {{ ternary "tmp" (printf "%s/%s" .Values.nextcloud.persistence.subPath "tmp") (empty .Values.nextcloud.persistence.subPath) }}
-        - name: nextcloud-data
+        - name: nextcloud-main
           mountPath: /var/www/html/themes
           subPath: {{ ternary "themes" (printf "%s/%s" .Values.nextcloud.persistence.subPath "themes") (empty .Values.nextcloud.persistence.subPath) }}
         - name: nextcloud-nginx-config
@@ -386,12 +398,17 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-      - name: nextcloud-data
+      - name: nextcloud-main
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud{{- end }}
       {{- else }}
         emptyDir: {}
+      {{- end }}
+      {{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
+      - name: nextcloud-data
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.nextcloudData.existingClaim }}{{ .Values.persistence.nextcloudData.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud-data{{- end }}
       {{- end }}
       {{- if .Values.nextcloud.configs }}
       - name: nextcloud-config

--- a/charts/nextcloud/templates/nextcloud-data-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-data-pvc.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.persistence.enabled .Values.persistence.nextcloudData.enabled -}}
+{{- if not .Values.persistence.nextcloudData.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-nextcloud-data
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: app
+{{- if .Values.persistence.nextcloudData.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.nextcloudData.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.nextcloudData.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.nextcloudData.size | quote }}
+{{- if .Values.persistence.nextcloudData.storageClass }}
+{{- if (eq "-" .Values.persistence.nextcloudData.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.nextcloudData.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -338,6 +338,17 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
+  ## Use an additional pvc for the data directory rather than a subpath of the default PVC
+  ## Useful to store data on a different storageClass (e.g. on slower disks)
+  nextcloudData:
+    enabled: false
+    subPath:
+    annotations: {}
+    # storageClass: "-"
+    # existingClaim:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
# Pull Request

## Description of the change

implements partial #110.
We add the possibility to move data directory in a different PVC by setting a config flag.
This is DISABLED by default

## Benefits

In order to profit from different storage classes (e.g. high speed SSD and slow HDD) and special limits on the data.

## Possible drawbacks

If enabled creating a second PVC needs a few more ressources.
We might have problems if we want to delete this feature in the future with backwards compability.

## Applicable issues

no known

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
