### PR TITLE
Add Helm version requirement to readme

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -19,6 +19,7 @@ It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/chart
 
 - Kubernetes 1.9+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
+- Helm >=3.7.0 ([for subchart scope exposing](nextcloud/helm#152))
 
 ## Installing the Chart
 


### PR DESCRIPTION
# Add Helm version requirement to readme

## Description of the change

Took me quite a while to figure out that Helm >=3.7.0 is necessary for this chart since #152. <br>
In my case for example ArgoCD uses Helm v3.6.0 and therefore could not render the templates if MariaDB is enabled.

## Benefits

May save the time of other people

## Possible drawbacks

Don't see any, only a readme addition

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).

