### PR TITLE
document correct defaults for existingSecret credentials keys

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.4.4
+version: 3.4.5
 appVersion: 25.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -257,8 +257,8 @@ externalDatabase:
   existingSecret:
     enabled: false
     # secretName: nameofsecret
-    # usernameKey: username
-    # passwordKey: password
+    # usernameKey: db-username
+    # passwordKey: db-password
 
 ##
 ## MariaDB chart configuration

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -78,11 +78,11 @@ nextcloud:
   existingSecret:
     enabled: false
     # secretName: nameofsecret
-    # usernameKey: username
-    # passwordKey: password
-    # tokenKey: serverinfo_token
-    # smtpUsernameKey: smtp_username
-    # smtpPasswordKey: smtp_password
+    # usernameKey: nextcloud-username
+    # passwordKey: nextcloud-password
+    # tokenKey: nextcloud-token
+    # smtpUsernameKey: smtp-username
+    # smtpPasswordKey: smtp-password
   update: 0
   # If web server is not binding default port, you can define it
   # containerPort: 8080


### PR DESCRIPTION
# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The values indicated in the comments are not what the chart actually uses as defaults.

## Benefits

<!-- What benefits will be realized by the code change? -->

First-time users looking through `values.yaml` know how to configure the secrets correctly.

## Possible drawbacks

<!-- Describe any known limitations with your change -->

None I can think of

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
none

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
none

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).

I don’t think these are necessary, since this change only affects documentation:
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
