### PR TITLE
docs: Preserving source IP

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -275,8 +275,8 @@ nextcloud:
 ## Preserving Source IP
 
 - Make sure your loadbalancer preserves source IP, for bare metal, `metalb` does and `klipper-lb` doesn't.
-- Make sure your Ingress preserves source IP. If you you ingress-nginx, add the following annotations:
-```
+- Make sure your Ingress preserves source IP. If you use `ingress-nginx`, add the following annotations:
+```yaml
 ingress:
   annotations:
    nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -284,7 +284,7 @@ ingress:
 ```
 - The next layer is nextcloud pod's nginx if you use `nextcloud-fpm`, this can be left at default
 - Add some PHP config for nextcloud as mentioned above in multiple `config.php`s section:
-```
+```php
   configs:
     proxy.config.php: |-
       <?php

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -272,6 +272,31 @@ nextcloud:
       );
 ```
 
+## Preserving Source IP
+
+- Make sure your loadbalancer preserves source IP, for bare metal, `metalb` does and `klipper-lb` doesn't.
+- Make sure your Ingress preserves source IP. If you you ingress-nginx, add the following annotations:
+```
+ingress:
+  annotations:
+   nginx.ingress.kubernetes.io/enable-cors: "true"
+   nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For"
+```
+- The next layer is nextcloud pod's nginx if you use `nextcloud-fpm`, this can be left at default
+- Add some PHP config for nextcloud as mentioned above in multiple `config.php`s section:
+```
+  configs:
+    proxy.config.php: |-
+      <?php
+      $CONFIG = array (
+        'trusted_proxies' => array(
+          0 => '127.0.0.1',
+          1 => '10.0.0.0/8',
+        ),
+        'forwarded_for_headers' => array('HTTP_X_FORWARDED_FOR'),
+      );
+```
+
 ## Hugepages
 
 If your node has hugepages enabled, but you do not map any into the container, it could fail to start with a bus error in Apache. This is due


### PR DESCRIPTION
# Pull Request

## Preserving source IP

Added documentation on how to preserve source IP

## Benefits

Preserving source IP is important when having a deployment with Kubernetes when nextcloud is behind proxies and ingresses. 

## Possible drawbacks

This might only address baremetal deployment and not managed k8s clusters.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
