### PR TITLE
fix nextcloud metrics

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.12.0
+version: 2.12.1
 appVersion: 22.2.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -275,8 +275,8 @@ nextcloud:
 ## Preserving Source IP
 
 - Make sure your loadbalancer preserves source IP, for bare metal, `metalb` does and `klipper-lb` doesn't.
-- Make sure your Ingress preserves source IP. If you you ingress-nginx, add the following annotations:
-```
+- Make sure your Ingress preserves source IP. If you use `ingress-nginx`, add the following annotations:
+```yaml
 ingress:
   annotations:
    nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -284,7 +284,7 @@ ingress:
 ```
 - The next layer is nextcloud pod's nginx if you use `nextcloud-fpm`, this can be left at default
 - Add some PHP config for nextcloud as mentioned above in multiple `config.php`s section:
-```
+```php
   configs:
     proxy.config.php: |-
       <?php

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -272,6 +272,31 @@ nextcloud:
       );
 ```
 
+## Preserving Source IP
+
+- Make sure your loadbalancer preserves source IP, for bare metal, `metalb` does and `klipper-lb` doesn't.
+- Make sure your Ingress preserves source IP. If you you ingress-nginx, add the following annotations:
+```
+ingress:
+  annotations:
+   nginx.ingress.kubernetes.io/enable-cors: "true"
+   nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For"
+```
+- The next layer is nextcloud pod's nginx if you use `nextcloud-fpm`, this can be left at default
+- Add some PHP config for nextcloud as mentioned above in multiple `config.php`s section:
+```
+  configs:
+    proxy.config.php: |-
+      <?php
+      $CONFIG = array (
+        'trusted_proxies' => array(
+          0 => '127.0.0.1',
+          1 => '10.0.0.0/8',
+        ),
+        'forwarded_for_headers' => array('HTTP_X_FORWARDED_FOR'),
+      );
+```
+
 ## Hugepages
 
 If your node has hugepages enabled, but you do not map any into the container, it could fail to start with a bus error in Apache. This is due

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
         env:
         {{- if .Values.metrics.token }}
-        - name: NEXTCLOUD_TOKEN
+        - name: NEXTCLOUD_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -428,7 +428,7 @@ metrics:
 
   image:
     repository: xperimental/nextcloud-exporter
-    tag: v0.5.0
+    tag: 0.5.0
     pullPolicy: IfNotPresent
 
   ## Metrics exporter resource requests and limits


### PR DESCRIPTION
# Pull Request

## Description of the change

This PR foxes two issues of the metrics exporter implementation.

1. The current image is not v0.5.0, instead it is 0.5.0
2. The Environment variable for the token was renamed by the upstream project.

<!-- What benefits will be realized by the code change? -->
Metrics exporter will work again

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
