### PR TITLE
Configurable HostAlias for cronjob

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.13.2
+version: 2.14.0
 appVersion: 23.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -42,6 +42,10 @@ spec:
             - name: {{ . }}
           {{- end }}
           {{- end }}
+          {{- with .Values.cronjob.hostAliases }}
+          hostAliases:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ default .Values.image.repository .Values.cronjob.image.repository }}:{{ default .Values.image.tag .Values.cronjob.image.tag }}"

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -312,6 +312,8 @@ cronjob:
     #  cpu: 100m
     #  memory: 128Mi
 
+  # hostAliases: {}
+
   # If not set, nextcloud deployment one will be set
   # nodeSelector: {}
 


### PR DESCRIPTION
# Pull Request

## Description of the change

The k8s cronjob uses the Nextcloud host when it's doing it's curl. In some cases, the host isn't resolvable inside the cluster so the cronjob end with a _Could not resolve host_ error.

## Benefits

Configurable hostaliases allows to define a host entry for the nextcloud host in the cronjob host file so it's able to curl properly the cron endpoint from inside the k8s cluster.

## Possible drawbacks

None

## Applicable issues

None

## Additional information

None

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
