### PR TITLE
Bump nextcloud, dependencies and nextcloud-exporter

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
+  version: 11.1.17
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.8.1
+  version: 10.4.5
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.7.6
-digest: sha256:547d8121f861cb95a7886212256e22349483d2919e99f5b3eed1d7f5e548012e
-generated: "2022-02-24T09:13:37.390932518+01:00"
+  version: 16.8.4
+digest: sha256:be6be24b908b54408848dfc850aa63cf4c1991874dedecc456150c2632a3fa03
+generated: "2022-04-07T12:45:17.645748481+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
 version: 2.14.0
-appVersion: 23.0.2
+appVersion: 23.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.13.2
+version: 2.14.0
 appVersion: 23.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
   email: jeff@billimek.com
 dependencies:
 - name: postgresql
-  version: 10.16.*
+  version: 11.1.*
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: mariadb
-  version: 9.8.*
+  version: 10.4.*
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
 - name: redis
-  version: 15.7.*
+  version: 16.8.*
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -188,7 +188,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `metrics.token`                                              | Uses token for auth instead of username/password        | `""`                                        |
 | `metrics.timeout`                                            | When the scrape times out                               | `5s`                                        |
 | `metrics.image.repository`                                   | Nextcloud metrics exporter image name                   | `xperimental/nextcloud-exporter`            |
-| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                    | `0.5.0`                                    |
+| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                    | `0.5.1`                                     |
 | `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy            | `IfNotPresent`                              |
 | `metrics.podAnnotations`                                     | Additional annotations for metrics exporter             | not set                                     |
 | `metrics.podLabels`                                          | Additional labels for metrics exporter                  | not set                                     |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
         - name: REDIS_HOST
           value: {{ template "nextcloud.redis.fullname" . }}-master
         - name: REDIS_HOST_PORT
-          value: {{ .Values.redis.master.service.port | quote }}
+          value: {{ .Values.redis.master.service.ports.redis | quote }}
         {{- if and .Values.redis.auth.existingSecret .Values.redis.auth.existingSecretPasswordKey }}
         - name: REDIS_HOST_PASSWORD
           valueFrom:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -432,7 +432,7 @@ metrics:
 
   image:
     repository: xperimental/nextcloud-exporter
-    tag: 0.5.0
+    tag: 0.5.1
     pullPolicy: IfNotPresent
 
   ## Metrics exporter resource requests and limits


### PR DESCRIPTION
# Pull Request

## Description of the change
nextcloud 23.0.2 -> 23.0.3
nextcloud-exporter 0.5.0 -> 0.5.1

postgresql 10.16.2 -> 11.1.17
mariadb 9.8.1 -> 10.4.5
redis 15.7.6 -> 16.8.4

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md


@tvories 