### PR TITLE
Fixed use of k8s-based postgresql

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.14.1
+version: 2.14.2
 appVersion: 23.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -123,6 +123,11 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `mariadb.auth.password`                                      | Password for the database                               | `changeme`                                  |
 | `mariadb.auth.username`                                      | Database user to create                                 | `nextcloud`                                 |
 | `mariadb.auth.rootPassword`                                  | MariaDB admin password                                  | `nil`                                       |
+| `postgresql.enabled`                                         | Whether to use the PostgreSQL chart                     | `false`                                     |
+| `postgresql.global.postgresql.auth.username`                 | Database user to create                                 | `nextcloud`                                 |
+| `postgresql.global.postgresql.auth.password`                 | Password for the database                               | `changeme`                                  |
+| `postgresql.global.postgresql.auth.database`                 | Database name to create                                 | `nextcloud`                                 |
+| `postgresql.primary.persistence.enabled`                     | Whether or not to use PVC on PostgreSQL primary         | `false`                                     |
 | `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                     |
 | `redis.auth.enabled`                                         | Whether to enable password authentication with redis    | `true`                                      |
 | `redis.auth.password`                                        | The password redis uses                                 | `''`                                        |

--- a/charts/nextcloud/templates/db-secret.yaml
+++ b/charts/nextcloud/templates/db-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.mariadb.enabled .Values.externalDatabase.enabled }}
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.enabled .Values.postgresql.enabled }}
 {{- if not .Values.externalDatabase.existingSecret.enabled }}
 apiVersion: v1
 kind: Secret
@@ -14,6 +14,9 @@ data:
   {{- if .Values.mariadb.enabled }}
   db-password: {{ default "" .Values.mariadb.auth.password | b64enc | quote }}
   db-username: {{ default "" .Values.mariadb.auth.username | b64enc | quote }}
+  {{- else if .Values.postgresql.enabled }}
+  db-password: {{ default "" .Values.postgresql.global.postgresql.auth.password | b64enc | quote }}
+  db-username: {{ default "" .Values.postgresql.global.postgresql.auth.username | b64enc | quote }}
   {{- else }}
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
   db-username: {{ default "" .Values.externalDatabase.user | b64enc | quote }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -94,6 +94,25 @@ spec:
             secretKeyRef:
               name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
               key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
+        {{- else if .Values.postgresql.enabled }}
+        - name: POSTGRES_HOST
+          value: {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}
+        - name: POSTGRES_DB
+          {{- if .Values.postgresql.auth.database }}
+          value: {{ .Values.postgresql.auth.database | quote }}
+          {{ else }}
+          value: {{ .Values.postgresql.global.postgresql.auth.database | quote }}
+          {{- end }}
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
         {{- else }}
           {{- if eq .Values.externalDatabase.type "postgresql" }}
         - name: POSTGRES_HOST

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -260,12 +260,16 @@ mariadb:
 ##
 postgresql:
   enabled: false
-  postgresqlUsername: nextcloud
-  postgresqlPassword: changeme
-  postgresqlDatabase: nextcloud
-  persistence:
-    enabled: false
-    # storageClass: ""
+  global:
+    postgresql:
+      auth:
+        username: nextcloud
+        password: changeme
+        database: nextcloud
+  primary:
+    persistence:
+      enabled: false
+      # storageClass: ""
 
 ##
 ## Redis chart configuration


### PR DESCRIPTION
# Pull Request

## Description of the change

The change fixes use of kubernetes-based PostgreSQL installed by `postgresql` subchart.
Before the patch PostgreSQL instance was created but not used by NextCloud (config was still using SQLite).
The structure of values in NectCloud's chart for `postgresql` subchart was different from one in `postgresql` chart itself which caused incorrect user and database creation.

## Benefits

Now if `postgresql.enabled` is set to `true` with all other values kept default, the instance of PostgreSQL is created in kubernetes cluster and used by NextCloud instance being installed.

## Possible drawbacks

Not found.

## Applicable issues

#15 or #168 or #226 (probably)

## Additional information

None

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
