### PR TITLE
Allow to deploy a Prometheus Operator ServiceMonitor

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.14.2
+version: 2.14.5
 appVersion: 23.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -202,6 +202,12 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `metrics.service.nodePort`                                   | Metrics: NodePort for service type NodePort             | `nil`                                       |
 | `metrics.service.annotations`                                | Additional annotations for service metrics exporter     | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
 | `metrics.service.labels`                                     | Additional labels for service metrics exporter          | `{}`                                        |
+| `metrics.serviceMonitor.enabled`                             | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                |
+| `metrics.serviceMonitor.namespace`                           | Namespace in which Prometheus is running                | ``                                          |
+| `metrics.serviceMonitor.jobLabel`                            | The name of the label on the target service to use as the job name in prometheus | ``                 |
+| `metrics.serviceMonitor.interval`                            | Interval at which metrics should be scraped             | `30s`                                       |
+| `metrics.serviceMonitor.scrapeTimeout`                       | Specify the timeout after which the scrape is ended     | ``                                          |
+| `metrics.serviceMonitor.labels`                              | Extra labels for the ServiceMonitor                     | `{}                                         |
 
 > **Note**:
 >

--- a/charts/nextcloud/templates/metrics-service.yaml
+++ b/charts/nextcloud/templates/metrics-service.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "nextcloud.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: metrics
     {{- if .Values.metrics.service.labels -}}
     {{ toYaml .Values.metrics.service.labels | nindent 4 }}
     {{- end -}}
@@ -27,4 +28,5 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: metrics
 {{- end }}

--- a/charts/nextcloud/templates/metrics-servicemonitor.yaml
+++ b/charts/nextcloud/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  {{- if .Values..metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values..metrics.serviceMonitor.namespace | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.metrics.serviceMonitor.labels -}}
+    {{ toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end -}}
+spec:
+  jobLabel: {{ .Values.server.metrics.serviceMonitor.jobLabel | quote }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      path: "/"
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+{{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -459,6 +459,36 @@ metrics:
       prometheus.io/port: "9205"
     labels: {}
 
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+      ##
+    enabled: false
+
+    ## @param metrics.serviceMonitor.namespace Namespace in which Prometheus is running
+    ##
+    namespace: ""
+
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: 30s
+
+    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    scrapeTimeout: ""
+
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+
+
 rbac:
   enabled: false
   serviceaccount:


### PR DESCRIPTION
# Pull Request

## Description of the change

This allows to deploy a Prometheus Operator ServiceMonitor for the metrics scraping.

## Benefits

`prometheus.io/scrape` and `prometheus.io/port` are not really used anymore and instead of manually creating a ServiceMonitor this chart should allow to create the ServiceMonitor

## Possible drawbacks

none that I am aware off

## Applicable issues

none

## Additional information


## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
