### PR TITLE
Add Missing Registry to MariaDB InitContainer

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.14.3
+version: 2.14.4
 appVersion: 23.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -390,7 +390,7 @@ spec:
       {{- if .Values.mariadb.enabled }}
       initContainers:
       - name: mariadb-isalive
-        image: {{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
+        image: {{ .Values.mariadb.image.registry }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
         env:
           - name: MYSQL_USER
             valueFrom:


### PR DESCRIPTION
# Pull Request

## Description of the change

The mariadb-isalive initContainer is missing its registry parameter. It can only work with images pulled from docker.

I added the registry so it's rendering the same image URL as the bitnami chart dependency.

See mariadb documentation here: https://artifacthub.io/packages/helm/bitnami/mariadb/10.4.5#mariadb-common-parameters

## Benefits

Fixes cases where MariaDB image used is hosted in a registry different than docker.io. Also renders the same image value as the bitnami chart.

## Possible drawbacks

N/A

## Applicable issues

N/A

## Additional information

N/A

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
