### PR TITLE
update ingress snippet comment in values.yaml

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.8
+version: 3.5.9
 appVersion: 26.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.7
+version: 3.5.8
 appVersion: 26.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -30,8 +30,8 @@ ingress:
   #  nginx.ingress.kubernetes.io/server-snippet: |-
   #    server_tokens off;
   #    proxy_hide_header X-Powered-By;
-
-  #    rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
+  #    rewrite ^/.well-known/webfinger /index.php/.well-known/webfinger last;
+  #    rewrite ^/.well-known/nodeinfo /index.php/.well-known/nodeinfo last;
   #    rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
   #    rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json;
   #    location = /.well-known/carddav {


### PR DESCRIPTION
# Pull Request

## Description of the change

Update well-known webfinger and nodeinfo redirects to match documentation in https://docs.nextcloud.com/server/23/admin_manual/issues/general_troubleshooting.html#service-discovery

## Benefits

People just uncommenting the snippet will now have correct webfinger config, and no warnings in the nextcloud settings.

## Possible drawbacks

None that I can see

## Applicable issues

#240 

## Additional information

...

## Checklist

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
