### PR TITLE
Support annotations on serviceaccount

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 2.14.4
+version: 2.14.5
 appVersion: 23.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -163,6 +163,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `rbac.enabled`                                               | Enable Role and rolebinding for priveledged PSP         | `false`                                     |
 | `rbac.serviceaccount.create`                                 | Wether to create a serviceaccount or use an existing one (requires rbac) | `true`                     |
 | `rbac.serviceaccount.name`                                   | The name of the sevice account that the deployment will use (requires rbac) | `nextcloud-serviceaccount` |
+| `rbac.serviceaccount.annotations`                            | Serviceaccount annotations                              | `{}`                                        |
 | `livenessProbe.enabled`                                      | Turn on and off liveness probe                          | `true`                                      |
 | `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                | `10`                                        |
 | `livenessProbe.periodSeconds`                                | How often to perform the probe                          | `10`                                        |

--- a/charts/nextcloud/templates/serviceaccount.yaml
+++ b/charts/nextcloud/templates/serviceaccount.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceaccount.name }}
+  {{- if .Values.rbac.serviceaccount.annotations }}
+  annotations:
+    {{- toYaml .Values.rbac.serviceaccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -470,3 +470,4 @@ rbac:
   serviceaccount:
     create: true
     name: nextcloud-serviceaccount
+    annotations: {}


### PR DESCRIPTION
Signed-off-by: Mikael Hammarin <mhammarin@ecit.com>

# Pull Request

## Description of the change

Adding the possibility to annotate the created service account

## Benefits

Would allow more use-cases when automating setup of a new nextcloud instance.
For instance, in GKE this allow automated setup of workload identity.

## Possible drawbacks

NA

## Applicable issues

NA

## Additional information

NA

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
