### PR TITLE
Use .Chart.AppVersion for image tag

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.0.1
+version: 3.0.2
 appVersion: 24.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | Parameter                                                    | Description                                             | Default                                     |
 | ------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------- |
 | `image.repository`                                           | nextcloud Image name                                    | `nextcloud`                                 |
+| `image.flavor`                                               | nextcloud Image type                                    | `apache`                                    |
 | `image.tag`                                                  | nextcloud Image tag                                     | `{VERSION}`                                 |
 | `image.pullPolicy`                                           | Image pull policy                                       | `IfNotPresent`                              |
 | `image.pullSecrets`                                          | Specify image pull secrets                              | `nil`                                       |

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -39,6 +39,18 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create image name that is used in the deployment
+*/}}
+{{- define "nextcloud.image" -}}
+{{- if .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s-%s" .Values.image.repository .Chart.AppVersion .Values.image.flavor -}}
+{{- end -}}
+{{- end -}}
+
+
 {{- define "nextcloud.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "nextcloud.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.lifecycle }}
         lifecycle:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -3,7 +3,9 @@
 ##
 image:
   repository: nextcloud
-  tag: 24.0.2-apache
+  flavor: apache
+  # If unset, uses flavor + .Chart.AppVersion to create tag
+  # tag:
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName


### PR DESCRIPTION
# Pull Request

## Description of the change

@tvories  this uses AppVersion if the tag key is unset and the tag key if set. I also added a flavor key which allows users to switch to a different image type (e.g. nginx or something else).

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
