### PR TITLE
extraInitContainers with Maria/PSQL

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.0.3
+version: 3.1.1
 appVersion: 24.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -52,10 +52,6 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
-      {{- if .Values.nextcloud.extraInitContainers }}
-      initContainers:
-      {{- toYaml .Values.nextcloud.extraInitContainers | nindent 8 }}
-      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "nextcloud.image" . }}
@@ -387,8 +383,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.mariadb.enabled }}
+      {{- if .Values.nextcloud.extraInitContainers or .Values.mariadb.enabled or .Values.postgresql.enabled }}
       initContainers:
+      {{- if .Values.nextcloud.extraInitContainers }}
+      {{- toYaml .Values.nextcloud.extraInitContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.mariadb.enabled }}
       - name: mariadb-isalive
         image: {{ .Values.mariadb.image.registry }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
         env:
@@ -407,7 +407,6 @@ spec:
           - "-c"
           - {{ printf "until mysql --host=%s-mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name }}
       {{- else if .Values.postgresql.enabled }}
-      initContainers:
       - name: postgresql-isready
         image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
         env:
@@ -420,6 +419,7 @@ spec:
           - "sh"
           - "-c"
           - {{ printf "until pg_isready -h %s-postgresql -U ${POSTGRES_USER} ; do sleep 2 ; done" .Release.Name }}
+      {{- end }}
       {{- end }}
     {{- with .Values.affinity }}
       affinity:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -383,7 +383,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.nextcloud.extraInitContainers or .Values.mariadb.enabled or .Values.postgresql.enabled }}
+      {{- if or .Values.nextcloud.extraInitContainers .Values.mariadb.enabled .Values.postgresql.enabled }}
       initContainers:
       {{- if .Values.nextcloud.extraInitContainers }}
       {{- toYaml .Values.nextcloud.extraInitContainers | nindent 8 }}


### PR DESCRIPTION
# Pull Request

## Description of the change

Init containers were not working when PG or mariaDB is enabled. No way to use `extraInitContainers` if `maria.enabled: true`.

## Benefits

Init containers are now working when PG or mariaDB is enabled.

## Possible drawbacks

N/A

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
