### PR TITLE
Fix "cronjob has no tag"

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.0.3
+version: 3.0.4
 appVersion: 24.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -44,7 +44,11 @@ spec:
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ default .Values.image.repository .Values.cronjob.image.repository }}:{{ default .Values.image.tag .Values.cronjob.image.tag }}"
+              {{- if and .Values.cronjob.image.repository .Values.cronjob.image.tag }}
+              image: "{{ .Values.cronjob.image.repository }}:{{ .Values.cronjob.image.tag }}"
+              {{- else }}
+              image: {{ include "nextcloud.image" . }}
+              {{- end }}
               imagePullPolicy: {{ default .Values.image.pullPolicy .Values.cronjob.image.pullPolicy }}
               command: [ "curl" ]
               args:


### PR DESCRIPTION

# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This fixes #263

## Benefits

<!-- What benefits will be realized by the code change? -->
cronjobs are no longer broken for those who don't override the cronjob image and tag

## Possible drawbacks

<!-- Describe any known limitations with your change -->
You can only override the cronjob image by setting both a repository and a tag for it. Used to be that the tag defaulted to the Nextcloud image tag if you only set a repository (but I'm not sure if that's a sane default)

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #263 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
  - n/a
