### PR TITLE
Add security context for the cronjob, main container, main pod, and ngnix container

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.3.6
+version: 3.4.0
 appVersion: 25.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -100,6 +100,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.extraInitContainers`                              | specify additional init containers                      | `[]`                                        |
 | `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod        | `{}`                                        |
 | `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod  | `{}`                                        |
+| `nextcloud.securityContext`                                  | Optional security context for the NextCloud container   | `nil`                                       |
+| `nextcloud.podSecurityContext`                               | specify additional volume mounts for the NextCloud pod  | `nil`                                       |
 | `nginx.enabled`                                              | Enable nginx (requires you use php-fpm image)           | `false`                                     |
 | `nginx.image.repository`                                     | nginx Image name                                        | `nginx`                                     |
 | `nginx.image.tag`                                            | nginx Image tag                                         | `alpine`                                    |
@@ -107,6 +109,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nginx.config.default`                                       | Whether to use nextclouds recommended nginx config      | `true`                                      |
 | `nginx.config.custom`                                        | Specify a custom config for nginx                       | `{}`                                        |
 | `nginx.resources`                                            | nginx resources                                         | `{}`                                        |
+| `nginx.securityContext`                                      | Optional security context for the nginx container       | `nil`                                       |
 | `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand      | `nil`                                       |
 | `lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand        | `nil`                                       |
 | `internalDatabase.enabled`                                   | Whether to use internal sqlite database                 | `true`                                      |
@@ -137,6 +140,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                     |
 | `cronjob.lifecycle.postStartCommand`                         | Specify deployment lifecycle hook postStartCommand      | `nil`                                       |
 | `cronjob.lifecycle.preStopCommand`                           | Specify deployment lifecycle hook preStopCommand        | `nil`                                       |
+| `cronjob.securityContext`                                    | Optional security context for cronjob                   | `nil`                                       |
 | `service.type`                                               | Kubernetes Service type                                 | `ClusterIP`                                 |
 | `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer            | `nil`                                       |
 | `service.nodePort`                                           | NodePort for service type NodePort                      | `nil`                                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -121,10 +121,16 @@ spec:
           successThreshold: {{ .Values.startupProbe.successThreshold }}
           failureThreshold: {{ .Values.startupProbe.failureThreshold }}
         {{- end }}
-        volumeMounts:
-{{- include "nextcloud.volumeMounts" . | trim | nindent 8 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.nextcloud.securityContext}}
+        securityContext:
+          {{- with .Values.nextcloud.securityContext }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+        volumeMounts:
+        {{- include "nextcloud.volumeMounts" . | trim | nindent 8 }}
       {{- if .Values.cronjob.enabled }}
       - name: {{ .Chart.Name }}-cron
         image: {{ include "nextcloud.image" . }}
@@ -150,6 +156,12 @@ spec:
 {{- include "nextcloud.env" . | indent 8 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.cronjob.securityContext}}
+        securityContext:
+          {{- with .Values.cronjob.securityContext }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
         volumeMounts:
 {{- include "nextcloud.volumeMounts" . | trim | nindent 8 }}
       {{- end }}
@@ -192,6 +204,12 @@ spec:
 
         resources:
 {{ toYaml .Values.nginx.resources | indent 10 }}
+        {{- if .Values.nginx.securityContext}}
+        securityContext:
+          {{- with .Values.nginx.securityContext }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
         volumeMounts:
         - name: nextcloud-main
           mountPath: /var/www/
@@ -308,23 +326,23 @@ spec:
       {{- if .Values.nextcloud.extraVolumes }}
 {{ toYaml .Values.nextcloud.extraVolumes | indent 6 }}
       {{- end }}
-      {{- if .Values.nginx.enabled }}
-      # Will mount configuration files as www-data (id: 82) for nextcloud
       securityContext:
-        fsGroup: 82
-        {{- if .Values.securityContext }}
-        {{- with .Values.securityContext }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- if .Values.nextcloud.podSecurityContext }}
+        {{- with .Values.nextcloud.podSecurityContext }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- else }}
-      # Will mount configuration files as www-data (id: 33) for nextcloud
-      securityContext:
+        {{- if .Values.nginx.enabled }}
+        # Will mount configuration files as www-data (id: 82) for nextcloud
+        fsGroup: 82
+        {{- else }}
+        # Will mount configuration files as www-data (id: 33) for nextcloud
         fsGroup: 33
-        {{- if .Values.securityContext }}
-        {{- with .Values.securityContext }}
-        {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.securityContext }}
+          {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
         {{- end }}
       {{- end }}
       {{- if .Values.rbac.enabled }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -501,3 +501,7 @@ rbac:
     create: true
     name: nextcloud-serviceaccount
     annotations: {}
+
+
+## @param securityContext @deprecated Use `nextcloud.podSecurityContext` instead
+securityContext: {}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -190,8 +190,15 @@ nextcloud:
   #  - name: nfs
   #    mountPath: "/legacy_data"
 
-  # Extra secuurityContext parameters. For example you may need to define runAsNonRoot directive
-  # extraSecurityContext:
+  # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
+  securityContext: {}
+  #   runAsUser: "33"
+  #   runAsGroup: "33"
+  #   runAsNonRoot: true
+  #   readOnlyRootFilesystem: true
+
+  # Set securityContext parameters for the pod. For example, you may need to define runAsNonRoot directive
+  podSecurityContext: {}
   #   runAsUser: "33"
   #   runAsGroup: "33"
   #   runAsNonRoot: true
@@ -212,6 +219,13 @@ nginx:
     #     worker_processes  1;..
 
   resources: {}
+
+  # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
+  securityContext: {}
+  #   runAsUser: "82"
+  #   runAsGroup: "33"
+  #   runAsNonRoot: true
+  #   readOnlyRootFilesystem: true
 
 internalDatabase:
   enabled: true
@@ -308,6 +322,12 @@ cronjob:
   lifecycle: {}
     # postStartCommand: []
     # preStopCommand: []
+  # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
+  securityContext: {}
+  #   runAsUser: "33"
+  #   runAsGroup: "33"
+  #   runAsNonRoot: true
+  #   readOnlyRootFilesystem: true
 
 service:
   type: ClusterIP


### PR DESCRIPTION
# Pull Request

## Description of the change

Allows users to set the securityContext for the NextCloud pod, NextCloud container, nginx container, and the cronjob.

Based on #117 by @nlaille.

## Benefits

Allows users to set the securityContext for the NextCloud pod, NextCloud container, nginx container, and the cronjob.

## Possible drawbacks

Users can overwrite the default `runAs` property.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #186
- fixes #252

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
