### PR TITLE
Bump chart dependencies / nextcloud to 24.0.6 / nextcloud-exporter 0.6.0

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.10
+  version: 12.0.1
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.13
+  version: 11.3.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.12.3
-digest: sha256:fa5daab278b20ab0521819791750848c7cf8f4081bea4d675ce04faef5cbb547
-generated: "2022-06-28T20:46:18.681579184+02:00"
+  version: 17.3.7
+digest: sha256:cea57f2cdaefa1449b88578f63ba4579c8a5e69ab7da713ac1d7ca700be900ad
+generated: "2022-11-03T23:49:15.532246965+01:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.2.3
+version: 3.3.0
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
   email: jeff@billimek.com
 dependencies:
 - name: postgresql
-  version: 11.6.*
+  version: 12.0.*
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: mariadb
-  version: 11.0.*
+  version: 11.3.*
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
 - name: redis
-  version: 16.12.*
+  version: 17.3.*
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
 version: 3.3.0
-appVersion: 24.0.5
+appVersion: 24.0.7
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -3,7 +3,9 @@
 ##
 image:
   repository: nextcloud
-  # tag: 24.0.3-apache
+  flavor: apache
+  # If tag is unset, uses .Chart.AppVersion + flavor to create tag
+  # tag: e.g. 24.0.6-apache
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -420,7 +420,7 @@ metrics:
 
   image:
     repository: xperimental/nextcloud-exporter
-    tag: 0.5.1
+    tag: 0.6.0
     pullPolicy: IfNotPresent
 
   ## Metrics exporter resource requests and limits


### PR DESCRIPTION
# Pull Request

## Description of the change

This will update from redis 6.x to redis 7.0.
Update postgres from 14.x to 15.x
Update nextcloud-exporter to 0.6.0
Update nextcloud to 24.0.7 (latest patch)

## Benefits

Updated dependencies


## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
