### PR TITLE
Fix issue with service selector when running multiple instances

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.2.1
+version: 3.2.2
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -23,4 +23,5 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: app


### PR DESCRIPTION
Signed-off-by: Mikael Hammarin <mhammarin@ecit.com>

# Pull Request

## Description of the change

This fix make it possible to run multiple helm instances in the same namespace without traffic accidently being sent to all of them (service selector is not unique per instance). 

## Benefits

This allow multiple parallel instances of Nextcloud to be run in a single namespace without colliding.

## Possible drawbacks

This change make it impossible to lunch multiple deployments which will receive traffic from the same ingress.
However, I can't think of a reason why it would be intended behavior for multiple deployment to use the same service selector.

## Applicable issues

NA

## Additional information

NA

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
