### PR TITLE
Fix: extraVolumeMounts for Nginx Container

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.1
+version: 3.5.2
 appVersion: 25.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -241,6 +241,9 @@ spec:
         - name: nextcloud-nginx-config
           mountPath: /etc/nginx/nginx.conf
           subPath: nginx.conf
+        {{- if .Values.nextcloud.extraVolumeMounts }}
+          {{- toYaml .Values.nextcloud.extraVolumeMounts | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nextcloud.extraSidecarContainers }}
         {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
# Pull Request

## Description of the change

Add `extraVolumeMounts` to nginx container. `extraVolumes` are already applied to the container, just the mount is missing.

## Benefits

Lets you add extra volumes to nginx container.

## Possible drawbacks

Mounting volumes you might not want on the webserver?!

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
