### PR TITLE
Fix(nginx-config): Listen port based on nextcloud.containerPort

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.1.1
+version: 3.1.2
 appVersion: 24.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -44,7 +44,7 @@ data:
         }
 
         server {
-            listen 80;
+            listen {{ .Values.nextcloud.containerPort | default 80 }};
 
             # HSTS settings
             # WARNING: Only add the preload option once you read about


### PR DESCRIPTION
Signed-off-by: nold <nold@gnu.one>

# Pull Request

## Description of the change

If `nextcloud.containerPort` is set, it will configure nginx to listen to the specified port.

## Benefits

Allows nginx container to run rootless & follows the expected behavior of `nextcloud.containerPort`.

<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

Unexpected port change on update?!
<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
