### PR TITLE
Fixed redis password in clear text

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.1.2
+version: 3.1.3
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -193,15 +193,17 @@ spec:
           value: {{ template "nextcloud.redis.fullname" . }}-master
         - name: REDIS_HOST_PORT
           value: {{ .Values.redis.master.service.ports.redis | quote }}
-        {{- if and .Values.redis.auth.existingSecret .Values.redis.auth.existingSecretPasswordKey }}
+        {{- if .Values.redis.auth.enabled }}
         - name: REDIS_HOST_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if and .Values.redis.auth.existingSecret .Values.redis.auth.existingSecretPasswordKey }}
               name: {{ .Values.redis.auth.existingSecret }}
               key: {{ .Values.redis.auth.existingSecretPasswordKey }}
-        {{- else }}
-        - name: REDIS_HOST_PASSWORD
-          value: {{ .Values.redis.auth.password }}
+              {{- else }}
+              name: {{ printf "%s-redis" .Release.Name | trunc 63 | trimSuffix "-" }}
+              key: "redis-password"
+              {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.nextcloud.extraEnv }}


### PR DESCRIPTION
# Pull Request

## Description of the change

Always read redis password form secret.

## Benefits

Avoid printing the redis secret in clear text when applying the chart

## Possible drawbacks

Unknowns

## Applicable issues

None

## Additional information

None

## Checklist

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
