### PR TITLE
Metrics: skip nextcloud HTTPS TLS check

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.1.2
+version: 3.1.3
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.1.3
+version: 3.2.1
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -192,7 +192,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `podLabels`                                                  | Labels to be added at 'pod' level                       | not set                                     |
 | `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                     |
 | `metrics.enabled`                                            | Start Prometheus metrics exporter                       | `false`                                     |
-| `metrics.https`                                              | Defines if https is used to connect to nextcloud        | `false` (uses http)                         |
+| `metrics.https.enabled`                                      | Defines if https is used to connect to nextcloud        | `false` (uses http)                         |
+| `metrics.https.skipVerify`                                   | Skip TLS certificate verification when connecting to nextcloud        | `false`                     |
 | `metrics.token`                                              | Uses token for auth instead of username/password        | `""`                                        |
 | `metrics.timeout`                                            | When the scrape times out                               | `5s`                                        |
 | `metrics.image.repository`                                   | Nextcloud metrics exporter image name                   | `xperimental/nextcloud-exporter`            |

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: NEXTCLOUD_TIMEOUT
           value: {{ .Values.metrics.timeout }}
         - name: NEXTCLOUD_TLS_SKIP_VERIFY
-          value: {{ if .Values.metrics.https.skipVerify }}true{{ else }}false{{ end }}
+          value: {{ .Values.metrics.https.skipVerify | quote }}
         ports:
         - name: metrics
           containerPort: 9205

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -51,9 +51,11 @@ spec:
               key: {{ .Values.nextcloud.existingSecret.passwordKey | default "nextcloud-password" }}
         {{- end }}
         - name: NEXTCLOUD_SERVER
-          value: http{{ if .Values.metrics.https }}s{{ end }}://{{ .Values.nextcloud.host }}
+          value: http{{ if .Values.metrics.https.enabled }}s{{ end }}://{{ .Values.nextcloud.host }}
         - name: NEXTCLOUD_TIMEOUT
           value: {{ .Values.metrics.timeout }}
+        - name: NEXTCLOUD_TLS_SKIP_VERIFY
+          value: {{ if .Values.metrics.https.skipVerify }}true{{ else }}false{{ end }}
         ports:
         - name: metrics
           containerPort: 9205

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -433,7 +433,9 @@ metrics:
 
   replicaCount: 1
   # The metrics exporter needs to know how you serve Nextcloud either http or https
-  https: false
+  https: 
+    enabled: false
+    skipVerify: false
   # Use API token if set, otherwise fall back to password authentication
   # https://github.com/xperimental/nextcloud-exporter#token-authentication
   # Currently you still need to set the token manually in your nextcloud install


### PR DESCRIPTION
# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Add option to skip certificate verify when using metrics exporter and https for nextcloud ingress

## Benefits

We can use secure HTTPS and metrics exporter together!

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #291 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
