### PR TITLE
Fix #306 (extraVolumeMounts missing from deployment, wrong indent on extraInitContainers)

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.2.1
+version: 3.2.2
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -255,4 +255,7 @@ Create volume mounts for the nextcloud container as well as the cron sidecar con
   mountPath: {{ $nginxEnabled | ternary (printf "/usr/local/etc/php-fpm.d/%s" $key | quote) (printf "/usr/local/etc/php/conf.d/%s" $key | quote) }}
   subPath: {{ $key }}
 {{- end }}
+{{- if .Values.nextcloud.extraVolumeMounts }}
+{{ toYaml .Values.nextcloud.extraVolumeMounts }}
+{{- end -}}
 {{- end -}}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -231,7 +231,7 @@ spec:
       {{- if or .Values.nextcloud.extraInitContainers .Values.mariadb.enabled .Values.postgresql.enabled }}
       initContainers:
       {{- if .Values.nextcloud.extraInitContainers }}
-      {{- toYaml .Values.nextcloud.extraInitContainers | nindent 8 }}
+      {{- toYaml .Values.nextcloud.extraInitContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.mariadb.enabled }}
       - name: mariadb-isalive


### PR DESCRIPTION
# Pull Request

## Description of the change

Fix #306 :
 - extraVolumeMounts missing from deployment, was removed when moving mount to the helper template
 - wrong indent on extraInitContainers

## Benefits

Fix

## Possible drawbacks

None?

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #306

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
