### PR TITLE
Support for extra sidecars

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.2.2
+version: 3.2.3
 appVersion: 24.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.defaultConfigs.smtp\.config\.php`                 | Default configuration for smtp                          | `true`                                      |
 | `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                        |
 | `nextcloud.extraEnv`                                         | specify additional environment variables                | `{}`                                        |
+| `nextcloud.extraSidecarContainers`                           | specify additional sidecar containers                   | `[]`                                        |
 | `nextcloud.extraInitContainers`                              | specify additional init containers                      | `[]`                                        |
 | `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod        | `{}`                                        |
 | `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod  | `{}`                                        |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -224,6 +224,9 @@ spec:
           mountPath: /etc/nginx/nginx.conf
           subPath: nginx.conf
       {{- end }}
+      {{- with .Values.nextcloud.extraSidecarContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -169,6 +169,15 @@ nextcloud:
   #    image: busybox
   #    command: ['do', 'something']
 
+  # Extra sidecar containers.
+  extraSidecarContainers: []
+  #  - name: nextcloud-logger
+  #    image: busybox
+  #    command: [/bin/sh, -c, 'while ! test -f "/run/nextcloud/data/nextcloud.log"; do sleep 1; done; tail -n+1 -f /run/nextcloud/data/nextcloud.log']
+  #    volumeMounts:
+  #    - name: nextcloud-data
+  #      mountPath: /run/nextcloud/data
+
   # Extra mounts for the pods. Example shown is for connecting a legacy NFS volume
   # to NextCloud pods in Kubernetes. This can then be configured in External Storage
   extraVolumes:


### PR DESCRIPTION
Signed-off-by: Mikael Hammarin <mhammarin@ecit.com>

# Pull Request

## Description of the change

Support to add extra sidecars. A common pattern is to use sidecars to handle local log files so they are handled by cluster-level logging. For Nextcloud, this means handling of nextcloud.log and audit.log files.

## Benefits

In GKE and similar managed kubernetes it would be possible to output nextcloud.log and audit.log so it is handled with Google Logging and Monitoring.

## Possible drawbacks

NA

## Applicable issues

NA

## Additional information

NA

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
