### PR TITLE
Allow probe checks and Service to use containerPort if specified

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.3.3
+version: 3.3.4
 appVersion: 25.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort | default "http" }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -97,7 +97,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort | default "http" }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -111,7 +111,7 @@ spec:
         startupProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort | default "http" }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -165,7 +165,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort | default "http" }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -179,7 +179,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort | default "http" }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: http
+    targetPort: {{ .Values.nextcloud.containerPort | default "http" }}
     protocol: TCP
     name: http
     {{- if eq .Values.service.type "NodePort" }}


### PR DESCRIPTION
# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Note: This probably can and should fold into #278.

This allows `containerPort` to be used for the readiness/startup/liveness probes along with the `targetPort` of the Service, otherwise they default to 80 and fail if the httpd inside the container is listening on another port.

This is particularly important on OpenShift where by default you cannot access privileged ports.

## Benefits

<!-- What benefits will be realized by the code change? -->
Makes it easier for OpenShift users? :)

## Possible drawbacks

<!-- Describe any known limitations with your change -->
There should not be any - the old default is kept if `containerPort` isn't defined.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
