### PR TITLE
Fix for #213 missing rewrite in default nginx.conf breaks LDAP

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.3.3
+version: 3.3.4
 appVersion: 25.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.15
+version: 3.5.16
 appVersion: 27.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -134,6 +134,9 @@ data:
             # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
             # to the URI, resulting in a HTTP 500 error response.
             location ~ \.php(?:$|/) {
+                # Required for legacy support
+                rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
                 fastcgi_split_path_info ^(.+?\.php)(/.*)$;
                 set $path_info $fastcgi_path_info;
 


### PR DESCRIPTION
Signed-off-by: Mike Kao (github@thetall.gent)

# Pull Request

## Description of the change

Missing rewrite in default nginx config breaks LDAP. Adding that rewrite in that exists in other installation methods.

## Benefits

Enables LDAP to work correctly in NC25

## Possible drawbacks

None

## Applicable issues

- fixes #213 

## Additional information

https://github.com/nextcloud/server/issues/35594

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
