### PR TITLE
Update PR template to not include bumping the chart version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Please do not bump the Chart version! -->
+
 # Pull Request
 
 ## Description of the change
@@ -24,5 +26,4 @@
 ## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
 
 - [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
-- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
 - [ ] (optional) Variables are documented in the README.md

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,4 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+check-version-increment: false


### PR DESCRIPTION
# Pull Request

## Description of the change

Removes the requirement for bumping the Chart version in PRs.

## Benefits

Collecting multiple PRs before making a new release and also avoid rebasing PRs so often.

## Possible drawbacks

None

## Applicable issues


## Additional information

Discussed in the [NC Containers public chat](https://cloud.nextcloud.com/call/oefq5xvp)  with @tvories 

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
