### PR TITLE
Add metrics.tlsSkipVerify and update default metrics exporter image tag to 0.6.0

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.3.4
+version: 3.3.5
 appVersion: 25.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -189,6 +189,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `metrics.https`                                              | Defines if https is used to connect to nextcloud        | `false` (uses http)                         |
 | `metrics.token`                                              | Uses token for auth instead of username/password        | `""`                                        |
 | `metrics.timeout`                                            | When the scrape times out                               | `5s`                                        |
+| `metrics.tlsSkipVerify`                                      | Skips certificate verification of Nextcloud server      | `false`                                    |
 | `metrics.image.repository`                                   | Nextcloud metrics exporter image name                   | `xperimental/nextcloud-exporter`            |
 | `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                    | `0.5.1`                                     |
 | `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy            | `IfNotPresent`                              |

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           value: http{{ if .Values.metrics.https }}s{{ end }}://{{ .Values.nextcloud.host }}
         - name: NEXTCLOUD_TIMEOUT
           value: {{ .Values.metrics.timeout }}
+        - name: NEXTCLOUD_TLS_SKIP_VERIFY
+          value: {{ .Values.metrics.tlsSkipVerify }}
         ports:
         - name: metrics
           containerPort: 9205

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -417,6 +417,8 @@ metrics:
   # Currently you still need to set the token manually in your nextcloud install
   token: ""
   timeout: 5s
+  # if set to true, exporter skips certificate verification of Nextcloud server.
+  tlsSkipVerify: false
 
   image:
     repository: xperimental/nextcloud-exporter

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -422,7 +422,7 @@ metrics:
 
   image:
     repository: xperimental/nextcloud-exporter
-    tag: 0.5.1
+    tag: 0.6.0
     pullPolicy: IfNotPresent
 
   ## Metrics exporter resource requests and limits


### PR DESCRIPTION
# Pull Request

## Description of the change

- Updates default metrics exporter image tag from `0.5.1` to `0.6.0`

- Adds `metrics.tlsSkipVerify` to values.yaml and README.md (this is a boolean, and defaults to **false**)
- Adds `NEXTCLOUD_TLS_SKIP_VERIFY` env variable to metrics exporter deployment template

This environment variable is described here [xperimental/nextcloud-exporter#environment-variables](https://github.com/xperimental/nextcloud-exporter#environment-variables) with:

> Skip certificate verification of Nextcloud server.

## Benefits

Without this, if you have https set, and you do not have a valid SSL cert,  you will get this error in the pod logs:

```log
level=error msg="Error during scrape: Get \"https://nextcloud.yourdomain.com/ocs/v2.php/apps/serverinfo/api/v1/info?format=json\": x509: certificate signed by unknown authority"
```

This allows you to still utilize the [xperimental/nextcloud-exporter](https://github.com/xperimental/nextcloud-exporter) in non-production environments (or environments with self signed certs).

I've defaulted the variable to false, so that we do not default to insecure behavior.

## Possible drawbacks

Unsure, as the default would remain the same. This just gives configuration ability.

## Applicable issues

This is similar to this PR: #293

- fixes #291

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
