### PR TITLE
Add documentation for `primary.persistence.existingClaim` for mariadb and postgresql

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.4.1
+version: 3.4.2
 appVersion: 25.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -129,11 +129,14 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `mariadb.auth.password`                                      | Password for the database                               | `changeme`                                  |
 | `mariadb.auth.username`                                      | Database user to create                                 | `nextcloud`                                 |
 | `mariadb.auth.rootPassword`                                  | MariaDB admin password                                  | `nil`                                       |
+| `mariadb.primary.persistence.enabled`                        | Whether or not to Use a PVC on MariaDB primary          | `false`                                     |
+| `mariadb.primary.persistence.existingClaim`                  | Use an existing PVC for MariaDB primary                 | `nil`                                       |
 | `postgresql.enabled`                                         | Whether to use the PostgreSQL chart                     | `false`                                     |
 | `postgresql.global.postgresql.auth.username`                 | Database user to create                                 | `nextcloud`                                 |
 | `postgresql.global.postgresql.auth.password`                 | Password for the database                               | `changeme`                                  |
 | `postgresql.global.postgresql.auth.database`                 | Database name to create                                 | `nextcloud`                                 |
 | `postgresql.primary.persistence.enabled`                     | Whether or not to use PVC on PostgreSQL primary         | `false`                                     |
+| `postgresql.primary.persistence.existingClaim`               | Use an existing PVC for PostgreSQL primary              | `nil`                                       |
 | `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                     |
 | `redis.auth.enabled`                                         | Whether to enable password authentication with redis    | `true`                                      |
 | `redis.auth.password`                                        | The password redis uses                                 | `''`                                        |

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -279,6 +279,8 @@ mariadb:
   primary:
     persistence:
       enabled: false
+      # Use an existing Persistent Volume Claim (must be created ahead of time)
+      # existingClaim: ""
       # storageClass: ""
       accessMode: ReadWriteOnce
       size: 8Gi
@@ -298,6 +300,8 @@ postgresql:
   primary:
     persistence:
       enabled: false
+      # Use an existing Persistent Volume Claim (must be created ahead of time)
+      # existingClaim: ""
       # storageClass: ""
 
 ##


### PR DESCRIPTION
# Pull Request

## Description of the change
This is just documenting already present and working features:

- Adds a commented option for both mariadb and postgresql for existingClaim
- Updates README.md with same options

## Benefits

Prevent people from having to cross-reference multiple charts' READMEs.

## Possible drawbacks

Think we're good to update the readme and comments without any drawbacks :)

## Applicable issues
- fixes #281 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Don't think we need to update the Chart Version for this, but updating the chart version next time there's a change to the actual code, will update the `values.yaml` that outputs when you do `helm show values nextcloud/nextcloud`. In the meantime, it's just a couple of comments, so a minor chart version doesn't even seem necessary.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md