### PR TITLE
update release branch from master to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'README.md'
       - 'charts/**/README.md'


### PR DESCRIPTION
# Pull Request

## Description of the change

Updates default release branch from `master` to `main`

## Benefits

Makes the repo more accessible and keeps us in line with industry standards as listed out in #340.

## Possible drawbacks

May be good to wait until we update the official default branch from master to main, so that there is not any confusion. may also be good to hold off on this specific change if we end up using a tag based release method, as it would just introduce more commits that may be confusing to track.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #340 

## Additional information
I've prepped this PR to make it easier to move forward after getting a maintainer to update the branch name, but it will remain in draft until #339 and #321 are resolved.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
