### PR TITLE
Create issue templates and link to code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,25 @@
+---
+name: "Enhancement"
+about: "Suggest an enhancement for this project ✨"
+title: "Feature: A cool new feature..."
+labels: "enhancement"
+assignees: ''
+
+---
+## Description of the change
+
+<!-- Describe the scope of your change - i.e. what the change does. -->
+
+## Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+## Possible drawbacks
+
+<!-- Describe any known limitations with your change -->
+
+## Additional information
+
+<!-- If there's anything else that's important and relevant to your pull request, mention that information here. -->
+
+<!-- Thanks for submitting an enhancement! Please consider also submitting a pull request for your suggestion :) -->

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,34 @@
+---
+name: "General Issue"
+about: "Create an issue to report something not working."
+title: "A descriptive title of the issue"
+labels: ''
+assignees: ''
+
+---
+
+## Describe your Issue
+<!-- A clear and concise description of what the issue or bug is -->
+
+### Logs and Errors
+<!-- Give us any errors you're getting -->
+<!-- Let us know where you got the log, e.g. nextcloud container or nginx container -->
+<!-- You can get the pod logs with: `kubectl logs` (remove any sensitive data ahead of time) -->
+
+## Describe your Environment
+
+- Kubernetes distribution: <!-- examples: k3s, k0s, eks, gke -->
+
+- Helm Version (or App that manages helm): <!-- example: Using helm version 3.11, or include data about what is running helm, e.g. ArgoCD version 2.5.8 -->
+
+- Helm Chart Version: <!-- example: 3.4.3 -->
+
+- `values.yaml`:
+
+```yaml
+# paste your values.yaml (anonymize any sensitive data)
+```
+
+## Additional context, if any
+<!-- Also note any additional relevant info about your environment. -->
+<!-- example: If your issue is related to persistent volumes, let us know you're using NFS or EFS, for instance. -->

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,6 +6,8 @@ on:
       - 'README.md'
       - 'charts/**/README.md'
       - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
 
 jobs:
   lint-test:
@@ -14,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0        
+          fetch-depth: 0
 
       - name: Install Helm
         uses: azure/setup-helm@v3.1

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,6 +8,7 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'
+      - 'CODE_OF_CONDUCT.md'
 
 jobs:
   lint-test:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+In the Nextcloud community, participants from all over the world come together to create Free Software for a free internet. This is made possible by the support, hard work and enthusiasm of thousands of people, including those who create and use Nextcloud software.
+
+Our code of conduct offers some guidance to ensure Nextcloud participants can cooperate effectively in a positive and inspiring atmosphere, and to explain how together we can strengthen and support each other.
+
+The Code of Conduct is shared by all contributors and users who engage with the Nextcloud team and its community services. It presents a summary of the shared values and “common sense” thinking in our community.
+
+You can find our full code of conduct on our website: https://nextcloud.com/code-of-conduct/
+
+Please, keep our CoC in mind when you contribute! That way, everyone can be a part of our community in a productive, positive, creative and fun way.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ helm repo update
   ```bash
   helm install my-release nextcloud/nextcloud
   ```
+
+For more information, please checkout the chart level [README.md](./helm/charts/nextcloud/README.md).
+
+### Support and Contribution
+Please also review the official [NextCloud Code of Conduct](https://nextcloud.com/contribute/code-of-conduct/) before contributing.
+
+#### Questions and Discussions
+[GitHub Discussion](https://github.com/nextcloud/helm/discussions)
+
+#### Bugs and other Issues
+If you have a bug to report or a feature to request, you can first search the [GitHub Issues](https://github.com/nextcloud/helm/issues), and  if you can't find what you're looking for, feel free to open an issue.
+
+#### Contributing to the Code
+We're always happy to review a pull request :) Please just be sure to check the pull request template to make sure you fufill all the required checks, most importantly the [DCO](https://probot.github.io/apps/dco/).


### PR DESCRIPTION
# Pull Request

## Description of the change

- Add issue templates for enhancement vs issue
- Update README.md to link to issues, discussions, and code of conduct
- Add [Code of Conduct from nextcloud/docker](https://github.com/nextcloud/docker/blob/master/CODE_OF_CONDUCT.md)
- update the PR checks to not run on updates to issue/PR templates or code of conduct.

## Benefits

This make it so that we don't have to ping back and ask for more info like `values.yaml` or what version of helm they are running, so that we can get better data to help troubleshoot what's wrong, and collaborate faster on fixes together.

## Possible drawbacks

Right now I was hesitant to call the general issue template "bug" template, because we don't really know everything is a bug immediately, but we need a general issue template that still kinda covers bugs. I'm still open to discussion on a better name for the default template though 🤷

## Applicable issues

All future issues, haha :)

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
