### PR TITLE
fix: Unexpected mapping value error with `nextcloud.extraVolumeMounts` and `nginx.enabled`

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.2
+version: 3.5.3
 appVersion: 25.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -242,7 +242,7 @@ spec:
           mountPath: /etc/nginx/nginx.conf
           subPath: nginx.conf
         {{- if .Values.nextcloud.extraVolumeMounts }}
-          {{- toYaml .Values.nextcloud.extraVolumeMounts | indent 8 }}
+          {{- toYaml .Values.nextcloud.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.nextcloud.extraSidecarContainers }}


### PR DESCRIPTION
# Pull Request

## Description of the change

v3.5.2 of this Helm chart fails to install or upgrade if `nextcloud.extraVolumeMounts` has a value and `nginx.enabled=true`.

## Benefits

This will fix Helm upgrades

## Possible drawbacks

N/A

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #357 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
