### PR TITLE
Update docs to have sections and add existingSecret for mariadb, postgresql, and redis

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.3
+version: 3.5.4
 appVersion: 25.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -13,12 +13,17 @@ helm install my-release nextcloud/nextcloud
 
 This chart bootstraps an [nextcloud](https://hub.docker.com/_/nextcloud/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the nextcloud application.
+You will also need a database compatible with Nextcloud. For more info, please see the [Database Configuration](#database-configurations) section below.
+
+If you want to persist data accross installs and upgrades, you'll need to configure persistence. For more info, please see the [Persistence Configuration](#persistence-configurations) section below.
+
+We also package a Redis helm chart as an _optional_ caching system from Bitnami:
+- [Bitnami Redis Chart](https://github.com/bitnami/charts/tree/main/bitnami/redis)
 
 ## Prerequisites
 
-- Kubernetes 1.9+ with Beta APIs enabled
-- PV provisioner support in the underlying infrastructure
+- Kubernetes 1.20+
+- Persistent Volume provisioner support in the underlying infrastructure
 - Helm >=3.7.0 ([for subchart scope exposing](nextcloud/helm#152))
 
 ## Installing the Chart
@@ -48,173 +53,216 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                    | Description                                                                            | Default                                                      |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `image.repository`                                           | nextcloud Image name                                                                   | `nextcloud`                                                  |
-| `image.flavor`                                               | nextcloud Image type (Options: apache, fpm)                                            | `apache`                                                     |
-| `image.tag`                                                  | nextcloud Image tag                                                                    | `{VERSION}`                                                  |
-| `image.pullPolicy`                                           | Image pull policy                                                                      | `IfNotPresent`                                               |
-| `image.pullSecrets`                                          | Specify image pull secrets                                                             | `nil`                                                        |
-| `replicaCount`                                               | Number of nextcloud pods to deploy                                                     | `1`                                                          |
-| `ingress.className`                                          | Name of the ingress class to use                                                       | `nil`                                                        |
-| `ingress.enabled`                                            | Enable use of ingress controllers                                                      | `false`                                                      |
-| `ingress.servicePort`                                        | Ingress' backend servicePort                                                           | `http`                                                       |
-| `ingress.annotations`                                        | An array of service annotations                                                        | `nil`                                                        |
-| `ingress.labels`                                             | An array of service labels                                                             | `nil`                                                        |
-| `ingress.path`                                               | The `Path` to use in Ingress' `paths`                                                  | `/`                                                          |
-| `ingress.pathType`                                           | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                                                     |
-| `ingress.tls`                                                | Ingress TLS configuration                                                              | `[]`                                                         |
-| `nextcloud.host`                                             | nextcloud host to create application URLs                                              | `nextcloud.kube.home`                                        |
-| `nextcloud.username`                                         | User of the application                                                                | `admin`                                                      |
-| `nextcloud.password`                                         | Application password                                                                   | `changeme`                                                   |
-| `nextcloud.existingSecret.enabled`                           | Whether to use an existing secret or not                                               | `false`                                                      |
-| `nextcloud.existingSecret.secretName`                        | Name of the existing secret                                                            | `nil`                                                        |
-| `nextcloud.existingSecret.usernameKey`                       | Name of the key that contains the username                                             | `nil`                                                        |
-| `nextcloud.existingSecret.passwordKey`                       | Name of the key that contains the password                                             | `nil`                                                        |
-| `nextcloud.existingSecret.smtpUsernameKey`                   | Name of the key that contains the SMTP username                                        | `nil`                                                        |
-| `nextcloud.existingSecret.smtpPasswordKey`                   | Name of the key that contains the SMTP password                                        | `nil`                                                        |
-| `nextcloud.update`                                           | Trigger update if custom command is used                                               | `0`                                                          |
-| `nextcloud.containerPort`                                    | Customize container port when not running as root                                      | `80`                                                         |
-| `nextcloud.datadir`                                          | nextcloud data dir location                                                            | `/var/www/html/data`                                         |
-| `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                                               | `false`                                                      |
-| `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                                                         | `nil`                                                        |
-| `nextcloud.mail.domain`                                      | nextcloud mail domain                                                                  | `nil`                                                        |
-| `nextcloud.mail.smtp.host`                                   | SMTP hostname                                                                          | `nil`                                                        |
-| `nextcloud.mail.smtp.secure`                                 | SMTP connection `ssl` or empty                                                         | `''`                                                         |
-| `nextcloud.mail.smtp.port`                                   | Optional SMTP port                                                                     | `nil`                                                        |
-| `nextcloud.mail.smtp.authtype`                               | SMTP authentication method                                                             | `LOGIN`                                                      |
-| `nextcloud.mail.smtp.name`                                   | SMTP username                                                                          | `''`                                                         |
-| `nextcloud.mail.smtp.password`                               | SMTP password                                                                          | `''`                                                         |
-| `nextcloud.configs`                                          | Config files created in `/var/www/html/config`                                         | `{}`                                                         |
-| `nextcloud.persistence.subPath`                              | Set the subPath for nextcloud to use in volume                                         | `nil`                                                        |
-| `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                                                         |
-| `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`                                    | `true`                                                       |
-| `nextcloud.defaultConfigs.redis\.config\.php`                | Default Redis configuration                                                            | `true`                                                       |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`   | Default Apache configuration for rewrite urls                                          | `true`                                                       |
-| `nextcloud.defaultConfigs.apcu\.config\.php`                 | Default configuration to define APCu as local cache                                    | `true`                                                       |
-| `nextcloud.defaultConfigs.apps\.config\.php`                 | Default configuration for apps                                                         | `true`                                                       |
-| `nextcloud.defaultConfigs.autoconfig\.php`                   | Default auto-configuration for databases                                               | `true`                                                       |
-| `nextcloud.defaultConfigs.smtp\.config\.php`                 | Default configuration for smtp                                                         | `true`                                                       |
-| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`                                             |
-| `nextcloud.extraEnv`                                         | specify additional environment variables                                               | `{}`                                                         |
-| `nextcloud.extraSidecarContainers`                           | specify additional sidecar containers                                                  | `[]`                                                         |
-| `nextcloud.extraInitContainers`                              | specify additional init containers                                                     | `[]`                                                         |
-| `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod                                       | `{}`                                                         |
-| `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod                                 | `{}`                                                         |
-| `nextcloud.securityContext`                                  | Optional security context for the NextCloud container                                  | `nil`                                                        |
-| `nextcloud.podSecurityContext`                               | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                                                        |
-| `nginx.enabled`                                              | Enable nginx (requires you use php-fpm image)                                          | `false`                                                      |
-| `nginx.image.repository`                                     | nginx Image name                                                                       | `nginx`                                                      |
-| `nginx.image.tag`                                            | nginx Image tag                                                                        | `alpine`                                                     |
-| `nginx.image.pullPolicy`                                     | nginx Image pull policy                                                                | `IfNotPresent`                                               |
-| `nginx.config.default`                                       | Whether to use nextcloud's recommended nginx config                                    | `true`                                                       |
-| `nginx.config.custom`                                        | Specify a custom config for nginx                                                      | `{}`                                                         |
-| `nginx.resources`                                            | nginx resources                                                                        | `{}`                                                         |
-| `nginx.securityContext`                                      | Optional security context for the nginx container                                      | `nil`                                                        |
-| `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                                        |
-| `lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                                        |
-| `internalDatabase.enabled`                                   | Whether to use internal sqlite database                                                | `true`                                                       |
-| `internalDatabase.database`                                  | Name of the existing database                                                          | `nextcloud`                                                  |
-| `externalDatabase.enabled`                                   | Whether to use external database                                                       | `false`                                                      |
-| `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`                                          | `mysql`                                                      |
-| `externalDatabase.host`                                      | Host of the external database in form of `host:port`                                   | `nil`                                                        |
-| `externalDatabase.database`                                  | Name of the existing database                                                          | `nextcloud`                                                  |
-| `externalDatabase.user`                                      | Existing username in the external db                                                   | `nextcloud`                                                  |
-| `externalDatabase.password`                                  | Password for the above username                                                        | `nil`                                                        |
-| `externalDatabase.existingSecret.enabled`                    | Whether to use a existing secret or not                                                | `false`                                                      |
-| `externalDatabase.existingSecret.secretName`                 | Name of the existing secret                                                            | `nil`                                                        |
-| `externalDatabase.existingSecret.usernameKey`                | Name of the key that contains the username                                             | `nil`                                                        |
-| `externalDatabase.existingSecret.passwordKey`                | Name of the key that contains the password                                             | `nil`                                                        |
-| `mariadb.enabled`                                            | Whether to use the MariaDB chart                                                       | `false`                                                      |
-| `mariadb.auth.database`                                      | Database name to create                                                                | `nextcloud`                                                  |
-| `mariadb.auth.password`                                      | Password for the database                                                              | `changeme`                                                   |
-| `mariadb.auth.username`                                      | Database user to create                                                                | `nextcloud`                                                  |
-| `mariadb.auth.rootPassword`                                  | MariaDB admin password                                                                 | `nil`                                                        |
-| `mariadb.primary.persistence.enabled`                        | Whether or not to Use a PVC on MariaDB primary                                         | `false`                                                      |
-| `mariadb.primary.persistence.existingClaim`                  | Use an existing PVC for MariaDB primary                                                | `nil`                                                        |
-| `postgresql.enabled`                                         | Whether to use the PostgreSQL chart                                                    | `false`                                                      |
-| `postgresql.global.postgresql.auth.username`                 | Database user to create                                                                | `nextcloud`                                                  |
-| `postgresql.global.postgresql.auth.password`                 | Password for the database                                                              | `changeme`                                                   |
-| `postgresql.global.postgresql.auth.database`                 | Database name to create                                                                | `nextcloud`                                                  |
-| `postgresql.primary.persistence.enabled`                     | Whether or not to use PVC on PostgreSQL primary                                        | `false`                                                      |
-| `postgresql.primary.persistence.existingClaim`               | Use an existing PVC for PostgreSQL primary                                             | `nil`                                                        |
-| `redis.enabled`                                              | Whether to install/use redis for locking                                               | `false`                                                      |
-| `redis.auth.enabled`                                         | Whether to enable password authentication with redis                                   | `true`                                                       |
-| `redis.auth.password`                                        | The password redis uses                                                                | `''`                                                         |
-| `cronjob.enabled`                                            | Whether to enable/disable cronjob                                                      | `false`                                                      |
-| `cronjob.lifecycle.postStartCommand`                         | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                                        |
-| `cronjob.lifecycle.preStopCommand`                           | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                                        |
-| `cronjob.resources`                                          | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                                                      |
-| `cronjob.securityContext`                                    | Optional security context for cronjob                                                  | `nil`                                                        |
-| `service.type`                                               | Kubernetes Service type                                                                | `ClusterIP`                                                  |
-| `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer                                           | `nil`                                                        |
-| `service.nodePort`                                           | NodePort for service type NodePort                                                     | `nil`                                                        |
-| `persistence.enabled`                                        | Enable persistence using PVC                                                           | `false`                                                      |
-| `persistence.annotations`                                    | PVC annotations                                                                        | `{}`                                                         |
-| `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                                                 | `nil` (uses alpha storage class annotation)                  |
-| `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume                                              | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                                                   | `ReadWriteOnce`                                              |
-| `persistence.size`                                           | PVC Storage Request for nextcloud volume                                               | `8Gi`                                                        |
-| `persistence.nextcloudData.enabled`                          | Create a second PVC for the data folder in nextcloud                                   | `false`                                                      |
-| `persistence.nextcloudData.annotations`                      | see `persistence.annotations`                                                          | `{}`                                                         |
-| `persistence.nextcloudData.storageClass`                     | see `persistence.storageClass`                                                         | `nil` (uses alpha storage class annotation)                  |
-| `persistence.nextcloudData.existingClaim`                    | see `persistence.existingClaim`                                                        | `nil` (uses alpha storage class annotation)                  |
-| `persistence.nextcloudData.accessMode`                       | see `persistence.accessMode`                                                           | `ReadWriteOnce`                                              |
-| `persistence.nextcloudData.size`                             | see `persistence.size`                                                                 | `8Gi`                                                        |
-| `phpClientHttpsFix.enabled`                                  | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                                                      |
-| `phpClientHttpsFix.protocol`                                 | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                                                      |
-| `resources`                                                  | CPU/Memory resource requests/limits                                                    | `{}`                                                         |
-| `rbac.enabled`                                               | Enable Role and rolebinding for priveledged PSP                                        | `false`                                                      |
-| `rbac.serviceaccount.create`                                 | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                                                       |
-| `rbac.serviceaccount.name`                                   | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount`                                   |
-| `rbac.serviceaccount.annotations`                            | Serviceaccount annotations                                                             | `{}`                                                         |
-| `livenessProbe.enabled`                                      | Turn on and off liveness probe                                                         | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                                               | `10`                                                         |
-| `livenessProbe.periodSeconds`                                | How often to perform the probe                                                         | `10`                                                         |
-| `livenessProbe.timeoutSeconds`                               | When the probe times out                                                               | `5`                                                          |
-| `livenessProbe.failureThreshold`                             | Minimum consecutive failures for the probe                                             | `3`                                                          |
-| `livenessProbe.successThreshold`                             | Minimum consecutive successes for the probe                                            | `1`                                                          |
-| `readinessProbe.enabled`                                     | Turn on and off readiness probe                                                        | `true`                                                       |
-| `readinessProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                                              | `10`                                                         |
-| `readinessProbe.periodSeconds`                               | How often to perform the probe                                                         | `10`                                                         |
-| `readinessProbe.timeoutSeconds`                              | When the probe times out                                                               | `5`                                                          |
-| `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                             | `3`                                                          |
-| `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe                                            | `1`                                                          |
-| `startupProbe.enabled`                                       | Turn on and off startup probe                                                          | `false`                                                      |
-| `startupProbe.initialDelaySeconds`                           | Delay before readiness probe is initiated                                              | `30`                                                         |
-| `startupProbe.periodSeconds`                                 | How often to perform the probe                                                         | `10`                                                         |
-| `startupProbe.timeoutSeconds`                                | When the probe times out                                                               | `5`                                                          |
-| `startupProbe.failureThreshold`                              | Minimum consecutive failures for the probe                                             | `30`                                                         |
-| `startupProbe.successThreshold`                              | Minimum consecutive successes for the probe                                            | `1`                                                          |
-| `hpa.enabled`                                                | Boolean to create a HorizontalPodAutoscaler                                            | `false`                                                      |
-| `hpa.cputhreshold`                                           | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                                                         |
-| `hpa.minPods`                                                | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                                                          |
-| `hpa.maxPods`                                                | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                                                         |
-| `deploymentLabels`                                           | Labels to be added at 'deployment' level                                               | not set                                                      |
-| `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level                                          | not set                                                      |
-| `podLabels`                                                  | Labels to be added at 'pod' level                                                      | not set                                                      |
-| `podAnnotations`                                             | Annotations to be added at 'pod' level                                                 | not set                                                      |
-| `metrics.enabled`                                            | Start Prometheus metrics exporter                                                      | `false`                                                      |
-| `metrics.https`                                              | Defines if https is used to connect to nextcloud                                       | `false` (uses http)                                          |
-| `metrics.token`                                              | Uses token for auth instead of username/password                                       | `""`                                                         |
-| `metrics.timeout`                                            | When the scrape times out                                                              | `5s`                                                         |
-| `metrics.tlsSkipVerify`                                      | Skips certificate verification of Nextcloud server                                     | `false`                                                      |
-| `metrics.image.repository`                                   | Nextcloud metrics exporter image name                                                  | `xperimental/nextcloud-exporter`                             |
-| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                                                   | `0.5.1`                                                      |
-| `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy                                           | `IfNotPresent`                                               |
-| `metrics.podAnnotations`                                     | Additional annotations for metrics exporter                                            | not set                                                      |
-| `metrics.podLabels`                                          | Additional labels for metrics exporter                                                 | not set                                                      |
-| `metrics.service.type`                                       | Metrics: Kubernetes Service type                                                       | `ClusterIP`                                                  |
-| `metrics.service.loadBalancerIP`                             | Metrics: LoadBalancerIp for service type LoadBalancer                                  | `nil`                                                        |
-| `metrics.service.nodePort`                                   | Metrics: NodePort for service type NodePort                                            | `nil`                                                        |
-| `metrics.service.annotations`                                | Additional annotations for service metrics exporter                                    | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
-| `metrics.service.labels`                                     | Additional labels for service metrics exporter                                         | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`                             | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator           | `false`                                                      |
-| `metrics.serviceMonitor.namespace`                           | Namespace in which Prometheus is running                                               | ``                                                           |
-| `metrics.serviceMonitor.jobLabel`                            | The name of the label on the target service to use as the job name in prometheus       | ``                                                           |
-| `metrics.serviceMonitor.interval`                            | Interval at which metrics should be scraped                                            | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`                       | Specify the timeout after which the scrape is ended                                    | ``                                                           |
-| `metrics.serviceMonitor.labels`                              | Extra labels for the ServiceMonitor                                                    | `{}                                                          |
+| Parameter                                                            | Description                                                                            | Default                                      |
+|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
+| `image.repository`                                                   | nextcloud Image name                                                                   | `nextcloud`                                  |
+| `image.flavor`                                                       | nextcloud Image type (Options: apache, fpm)                                            | `apache`                                     |
+| `image.tag`                                                          | nextcloud Image tag                                                                    | `{VERSION}`                                  |
+| `image.pullPolicy`                                                   | Image pull policy                                                                      | `IfNotPresent`                               |
+| `image.pullSecrets`                                                  | Specify image pull secrets                                                             | `nil`                                        |
+| `replicaCount`                                                       | Number of nextcloud pods to deploy                                                     | `1`                                          |
+| `ingress.className`                                                  | Name of the ingress class to use                                                       | `nil`                                        |
+| `ingress.enabled`                                                    | Enable use of ingress controllers                                                      | `false`                                      |
+| `ingress.servicePort`                                                | Ingress' backend servicePort                                                           | `http`                                       |
+| `ingress.annotations`                                                | An array of service annotations                                                        | `nil`                                        |
+| `ingress.labels`                                                     | An array of service labels                                                             | `nil`                                        |
+| `ingress.path`                                                       | The `Path` to use in Ingress' `paths`                                                  | `/`                                          |
+| `ingress.pathType`                                                   | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                                     |
+| `ingress.tls`                                                        | Ingress TLS configuration                                                              | `[]`                                         |
+| `nextcloud.host`                                                     | nextcloud host to create application URLs                                              | `nextcloud.kube.home`                        |
+| `nextcloud.username`                                                 | User of the application                                                                | `admin`                                      |
+| `nextcloud.password`                                                 | Application password                                                                   | `changeme`                                   |
+| `nextcloud.existingSecret.enabled`                                   | Whether to use an existing secret or not                                               | `false`                                      |
+| `nextcloud.existingSecret.secretName`                                | Name of the existing secret                                                            | `nil`                                        |
+| `nextcloud.existingSecret.usernameKey`                               | Name of the key that contains the username                                             | `nil`                                        |
+| `nextcloud.existingSecret.passwordKey`                               | Name of the key that contains the password                                             | `nil`                                        |
+| `nextcloud.existingSecret.smtpUsernameKey`                           | Name of the key that contains the SMTP username                                        | `nil`                                        |
+| `nextcloud.existingSecret.smtpPasswordKey`                           | Name of the key that contains the SMTP password                                        | `nil`                                        |
+| `nextcloud.update`                                                   | Trigger update if custom command is used                                               | `0`                                          |
+| `nextcloud.containerPort`                                            | Customize container port when not running as root                                      | `80`                                         |
+| `nextcloud.datadir`                                                  | nextcloud data dir location                                                            | `/var/www/html/data`                         |
+| `nextcloud.mail.enabled`                                             | Whether to enable/disable email settings                                               | `false`                                      |
+| `nextcloud.mail.fromAddress`                                         | nextcloud mail send from field                                                         | `nil`                                        |
+| `nextcloud.mail.domain`                                              | nextcloud mail domain                                                                  | `nil`                                        |
+| `nextcloud.mail.smtp.host`                                           | SMTP hostname                                                                          | `nil`                                        |
+| `nextcloud.mail.smtp.secure`                                         | SMTP connection `ssl` or empty                                                         | `''`                                         |
+| `nextcloud.mail.smtp.port`                                           | Optional SMTP port                                                                     | `nil`                                        |
+| `nextcloud.mail.smtp.authtype`                                       | SMTP authentication method                                                             | `LOGIN`                                      |
+| `nextcloud.mail.smtp.name`                                           | SMTP username                                                                          | `''`                                         |
+| `nextcloud.mail.smtp.password`                                       | SMTP password                                                                          | `''`                                         |
+| `nextcloud.configs`                                                  | Config files created in `/var/www/html/config`                                         | `{}`                                         |
+| `nextcloud.persistence.subPath`                                      | Set the subPath for nextcloud to use in volume                                         | `nil`                                        |
+| `nextcloud.phpConfigs`                                               | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                                         |
+| `nextcloud.defaultConfigs.\.htaccess`                                | Default .htaccess to protect `/var/www/html/config`                                    | `true`                                       |
+| `nextcloud.defaultConfigs.redis\.config\.php`                        | Default Redis configuration                                                            | `true`                                       |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`           | Default Apache configuration for rewrite urls                                          | `true`                                       |
+| `nextcloud.defaultConfigs.apcu\.config\.php`                         | Default configuration to define APCu as local cache                                    | `true`                                       |
+| `nextcloud.defaultConfigs.apps\.config\.php`                         | Default configuration for apps                                                         | `true`                                       |
+| `nextcloud.defaultConfigs.autoconfig\.php`                           | Default auto-configuration for databases                                               | `true`                                       |
+| `nextcloud.defaultConfigs.smtp\.config\.php`                         | Default configuration for smtp                                                         | `true`                                       |
+| `nextcloud.strategy`                                                 | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`                             |
+| `nextcloud.extraEnv`                                                 | specify additional environment variables                                               | `{}`                                         |
+| `nextcloud.extraSidecarContainers`                                   | specify additional sidecar containers                                                  | `[]`                                         |
+| `nextcloud.extraInitContainers`                                      | specify additional init containers                                                     | `[]`                                         |
+| `nextcloud.extraVolumes`                                             | specify additional volumes for the NextCloud pod                                       | `{}`                                         |
+| `nextcloud.extraVolumeMounts`                                        | specify additional volume mounts for the NextCloud pod                                 | `{}`                                         |
+| `nextcloud.securityContext`                                          | Optional security context for the NextCloud container                                  | `nil`                                        |
+| `nextcloud.podSecurityContext`                                       | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                                        |
+| `nginx.enabled`                                                      | Enable nginx (requires you use php-fpm image)                                          | `false`                                      |
+| `nginx.image.repository`                                             | nginx Image name                                                                       | `nginx`                                      |
+| `nginx.image.tag`                                                    | nginx Image tag                                                                        | `alpine`                                     |
+| `nginx.image.pullPolicy`                                             | nginx Image pull policy                                                                | `IfNotPresent`                               |
+| `nginx.config.default`                                               | Whether to use nextcloud's recommended nginx config                                    | `true`                                       |
+| `nginx.config.custom`                                                | Specify a custom config for nginx                                                      | `{}`                                         |
+| `nginx.resources`                                                    | nginx resources                                                                        | `{}`                                         |
+| `nginx.securityContext`                                              | Optional security context for the nginx container                                      | `nil`                                        |
+| `lifecycle.postStartCommand`                                         | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
+| `lifecycle.preStopCommand`                                           | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
+| `redis.enabled`                                                      | Whether to install/use redis for locking                                               | `false`                                      |
+| `redis.auth.enabled`                                                 | Whether to enable password authentication with redis                                   | `true`                                       |
+| `redis.auth.password`                                                | The password redis uses                                                                | `''`                                         |
+| `redis.auth.existingSecret`                                          | The name of an existing secret with Redis® credentials                                 | `''`                                         |
+| `redis.auth.existingSecretPasswordKey`                               | Password key to be retrieved from existing secret                                      | `''`                                         |
+| `cronjob.enabled`                                                    | Whether to enable/disable cronjob                                                      | `false`                                      |
+| `cronjob.lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
+| `cronjob.lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
+| `cronjob.resources`                                                  | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                                         |
+| `cronjob.securityContext`                                            | Optional security context for cronjob                                                  | `nil`                                        |
+| `service.type`                                                       | Kubernetes Service type                                                                | `ClusterIP`                                  |
+| `service.loadBalancerIP`                                             | LoadBalancerIp for service type LoadBalancer                                           | `nil`                                        |
+| `service.nodePort`                                                   | NodePort for service type NodePort                                                     | `nil`                                        |
+| `phpClientHttpsFix.enabled`                                          | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                                      |
+| `phpClientHttpsFix.protocol`                                         | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                                      |
+| `resources`                                                          | CPU/Memory resource requests/limits                                                    | `{}`                                         |
+| `rbac.enabled`                                                       | Enable Role and rolebinding for priveledged PSP                                        | `false`                                      |
+| `rbac.serviceaccount.create`                                         | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                                       |
+| `rbac.serviceaccount.name`                                           | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount`                   |
+| `rbac.serviceaccount.annotations`                                    | Serviceaccount annotations                                                             | `{}`                                         |
+| `livenessProbe.enabled`                                              | Turn on and off liveness probe                                                         | `true`                                       |
+| `livenessProbe.initialDelaySeconds`                                  | Delay before liveness probe is initiated                                               | `10`                                         |
+| `livenessProbe.periodSeconds`                                        | How often to perform the probe                                                         | `10`                                         |
+| `livenessProbe.timeoutSeconds`                                       | When the probe times out                                                               | `5`                                          |
+| `livenessProbe.failureThreshold`                                     | Minimum consecutive failures for the probe                                             | `3`                                          |
+| `livenessProbe.successThreshold`                                     | Minimum consecutive successes for the probe                                            | `1`                                          |
+| `readinessProbe.enabled`                                             | Turn on and off readiness probe                                                        | `true`                                       |
+| `readinessProbe.initialDelaySeconds`                                 | Delay before readiness probe is initiated                                              | `10`                                         |
+| `readinessProbe.periodSeconds`                                       | How often to perform the probe                                                         | `10`                                         |
+| `readinessProbe.timeoutSeconds`                                      | When the probe times out                                                               | `5`                                          |
+| `readinessProbe.failureThreshold`                                    | Minimum consecutive failures for the probe                                             | `3`                                          |
+| `readinessProbe.successThreshold`                                    | Minimum consecutive successes for the probe                                            | `1`                                          |
+| `startupProbe.enabled`                                               | Turn on and off startup probe                                                          | `false`                                      |
+| `startupProbe.initialDelaySeconds`                                   | Delay before readiness probe is initiated                                              | `30`                                         |
+| `startupProbe.periodSeconds`                                         | How often to perform the probe                                                         | `10`                                         |
+| `startupProbe.timeoutSeconds`                                        | When the probe times out                                                               | `5`                                          |
+| `startupProbe.failureThreshold`                                      | Minimum consecutive failures for the probe                                             | `30`                                         |
+| `startupProbe.successThreshold`                                      | Minimum consecutive successes for the probe                                            | `1`                                          |
+| `hpa.enabled`                                                        | Boolean to create a HorizontalPodAutoscaler                                            | `false`                                      |
+| `hpa.cputhreshold`                                                   | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                                         |
+| `hpa.minPods`                                                        | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                                          |
+| `hpa.maxPods`                                                        | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                                         |
+| `deploymentLabels`                                                   | Labels to be added at 'deployment' level                                               | not set                                      |
+| `deploymentAnnotations`                                              | Annotations to be added at 'deployment' level                                          | not set                                      |
+| `podLabels`                                                          | Labels to be added at 'pod' level                                                      | not set                                      |
+| `podAnnotations`                                                     | Annotations to be added at 'pod' level                                                 | not set                                      |
+
+
+### Database Configurations
+By default, nextcloud will use a SQLite database. This is not recommended for production, but is enabled by default for testing purposes. When you are done testing, please set `internalDatabase.enabled` to `false`, and configure the `externalDatabase` parameters below.
+
+For convenience, we packages the following Bitnami charts for databases (feel free to choose _one_ below):
+- [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
+- [Bitnami PostgreSQL chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+
+If you choose to use one of the prepackaged Bitnami helm charts, you must configure both the `externalDatabase` parameters, and the parameters for the chart you choose. For instance, if you choose to use the Bitnami PostgreSQL chart that we've prepackaged, you need to also configure all the parameters for `postgresql`. You do not need to use the Bitnami helm charts. If you want to use an already configured database that you have externally, just set `internalDatabase.enabled` to `false`, and configure the `externalDatabase` parameters below.
+
+
+| Parameter                                                            | Description                                                                            | Default         |
+|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|-----------------|
+| `internalDatabase.enabled`                                           | Whether to use internal sqlite database                                                | `true`          |
+| `internalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`     |
+| `externalDatabase.enabled`                                           | Whether to use external database                                                       | `false`         |
+| `externalDatabase.type`                                              | External database type: `mysql`, `postgresql`                                          | `mysql`         |
+| `externalDatabase.host`                                              | Host of the external database in form of `host:port`                                   | `nil`           |
+| `externalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`     |
+| `externalDatabase.user`                                              | Existing username in the external db                                                   | `nextcloud`     |
+| `externalDatabase.password`                                          | Password for the above username                                                        | `nil`           |
+| `externalDatabase.existingSecret.enabled`                            | Whether to use a existing secret or not                                                | `false`         |
+| `externalDatabase.existingSecret.secretName`                         | Name of the existing secret                                                            | `nil`           |
+| `externalDatabase.existingSecret.usernameKey`                        | Name of the key that contains the username                                             | `nil`           |
+| `externalDatabase.existingSecret.passwordKey`                        | Name of the key that contains the password                                             | `nil`           |
+| `mariadb.enabled`                                                    | Whether to use the MariaDB chart                                                       | `false`         |
+| `mariadb.auth.database`                                              | Database name to create                                                                | `nextcloud`     |
+| `mariadb.auth.username`                                              | Database user to create                                                                | `nextcloud`     |
+| `mariadb.auth.password`                                              | Password for the database                                                              | `changeme`      |
+| `mariadb.auth.rootPassword`                                          | MariaDB admin password                                                                 | `nil`           |
+| `mariadb.auth.existingSecret`                                        | Use existing secret for MariaDB password details; see values.yaml for more detail      | `''`            |
+| `mariadb.primary.persistence.enabled`                                | Whether or not to Use a PVC on MariaDB primary                                         | `false`         |
+| `mariadb.primary.persistence.existingClaim`                          | Use an existing PVC for MariaDB primary                                                | `nil`           |
+| `postgresql.enabled`                                                 | Whether to use the PostgreSQL chart                                                    | `false`         |
+| `postgresql.global.postgresql.auth.database`                         | Database name to create                                                                | `nextcloud`     |
+| `postgresql.global.postgresql.auth.username`                         | Database user to create                                                                | `nextcloud`     |
+| `postgresql.global.postgresql.auth.password`                         | Password for the database                                                              | `changeme`      |
+| `postgresql.global.postgresql.auth.existingSecret`                   | Name of existing secret to use for PostgreSQL credentials                              | `''`            |
+| `postgresql.global.postgresql.auth.secretKeys.adminPasswordKey`      | Name of key in existing secret to use for PostgreSQL admin password                    | `''`            |
+| `postgresql.global.postgresql.auth.secretKeys.userPasswordKey`       | Name of key in existing secret to use for PostgreSQL user password                     | `''`            |
+| `postgresql.global.postgresql.auth.secretKeys.replicationPasswordKey`| Name of key in existing secret to use for PostgreSQL replication password              | `''`            |
+| `postgresql.primary.persistence.enabled`                             | Whether or not to use PVC on PostgreSQL primary                                        | `false`         |
+| `postgresql.primary.persistence.existingClaim`                       | Use an existing PVC for PostgreSQL primary                                             | `nil`           |
+
+Is there a missing parameter for one of the Bitnami helm charts listed above? Please feel free to submit a PR to add that parameter in our values.yaml, but be sure to also update this README file :)
+
+
+### Persistence Configurations
+
+The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
+Persistent Volume Claims are used to keep the data across deployments. This is known to work with GKE, EKS, K3s, and minikube.
+
+
+| Parameter                                                            | Description                                                                            | Default                                      |
+|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
+| `persistence.enabled`                                                | Enable persistence using PVC                                                           | `false`                                      |
+| `persistence.annotations`                                            | PVC annotations                                                                        | `{}`                                         |
+| `persistence.storageClass`                                           | PVC Storage Class for nextcloud volume                                                 | `nil` (uses alpha storage class annotation)  |
+| `persistence.existingClaim`                                          | An Existing PVC name for nextcloud volume                                              | `nil` (uses alpha storage class annotation)  |
+| `persistence.accessMode`                                             | PVC Access Mode for nextcloud volume                                                   | `ReadWriteOnce`                              |
+| `persistence.size`                                                   | PVC Storage Request for nextcloud volume                                               | `8Gi`                                        |
+| `persistence.nextcloudData.enabled`                                  | Create a second PVC for the data folder in nextcloud                                   | `false`                                      |
+| `persistence.nextcloudData.annotations`                              | see `persistence.annotations`                                                          | `{}`                                         |
+| `persistence.nextcloudData.storageClass`                             | see `persistence.storageClass`                                                         | `nil` (uses alpha storage class annotation)  |
+| `persistence.nextcloudData.existingClaim`                            | see `persistence.existingClaim`                                                        | `nil` (uses alpha storage class annotation)  |
+| `persistence.nextcloudData.accessMode`                               | see `persistence.accessMode`                                                           | `ReadWriteOnce`                              |
+| `persistence.nextcloudData.size`                                     | see `persistence.size`                                                                 | `8Gi`                                        |
+
+
+### Metrics Configurations
+
+We include an optional experimental Nextcloud Metrics exporter from [xperimental/nextcloud-exporter](https://github.com/xperimental/nextcloud-exporter).
+
+| Parameter                              | Description                                                                     | Default                                                      |
+|----------------------------------------|---------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                      | Start Prometheus metrics exporter                                               | `false`                                                      |
+| `metrics.https`                        | Defines if https is used to connect to nextcloud                                | `false` (uses http)                                          |
+| `metrics.token`                        | Uses token for auth instead of username/password                                | `""`                                                         |
+| `metrics.timeout`                      | When the scrape times out                                                       | `5s`                                                         |
+| `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                              | `false`                                                      |
+| `metrics.image.repository`             | Nextcloud metrics exporter image name                                           | `xperimental/nextcloud-exporter`                             |
+| `metrics.image.tag`                    | Nextcloud metrics exporter image tag                                            | `0.6.0`                                                      |
+| `metrics.image.pullPolicy`             | Nextcloud metrics exporter image pull policy                                    | `IfNotPresent`                                               |
+| `metrics.podAnnotations`               | Additional annotations for metrics exporter                                     | not set                                                      |
+| `metrics.podLabels`                    | Additional labels for metrics exporter                                          | not set                                                      |
+| `metrics.service.type`                 | Metrics: Kubernetes Service type                                                | `ClusterIP`                                                  |
+| `metrics.service.loadBalancerIP`       | Metrics: LoadBalancerIp for service type LoadBalancer                           | `nil`                                                        |
+| `metrics.service.nodePort`             | Metrics: NodePort for service type NodePort                                     | `nil`                                                        |
+| `metrics.service.annotations`          | Additional annotations for service metrics exporter                             | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
+| `metrics.service.labels`               | Additional labels for service metrics exporter                                  | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator    | `false`                                                      |
+| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                        | ``                                                           |
+| `metrics.serviceMonitor.jobLabel`      | Name of the label on the target service to use as the job name in prometheus    | ``                                                           |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                     | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                             | ``                                                           |
+| `metrics.serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                             | `{}                                                          |
+
+
 
 > **Note**:
 >
@@ -247,13 +295,6 @@ helm install --name my-release -f values.yaml nextcloud/nextcloud
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-## Persistence
-
-The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
-
-Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
-See the [Configuration](#configuration) section to enable persistence and configuration of the PVC.
 
 ## Cronjob
 

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -265,7 +265,7 @@ externalDatabase:
 ## ref: https://github.com/bitnami/charts/tree/main/bitnami/mariadb
 ##
 mariadb:
-  ## Whether to deploy a mariadb server from the bitnami mariab db helm chart 
+  ## Whether to deploy a mariadb server from the bitnami mariab db helm chart
   # to satisfy the applications database requirements. if you want to deploy this bitnami mariadb, set this and externalDatabase to true
   # To use an ALREADY DEPLOYED mariadb database, set this to false and configure the externalDatabase parameters
   enabled: false
@@ -300,7 +300,7 @@ postgresql:
   enabled: false
   global:
     postgresql:
-      # global.postgresql.auth overrides postgresql.auth 
+      # global.postgresql.auth overrides postgresql.auth
       auth:
         username: nextcloud
         password: changeme

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -262,15 +262,21 @@ externalDatabase:
 
 ##
 ## MariaDB chart configuration
+## ref: https://github.com/bitnami/charts/tree/main/bitnami/mariadb
 ##
 mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ## Whether to deploy a mariadb server from the bitnami mariab db helm chart 
+  # to satisfy the applications database requirements. if you want to deploy this bitnami mariadb, set this and externalDatabase to true
+  # To use an ALREADY DEPLOYED mariadb database, set this to false and configure the externalDatabase parameters
   enabled: false
 
   auth:
     database: nextcloud
     username: nextcloud
     password: changeme
+    # Use existing secret (auth.rootPassword, auth.password, and auth.replicationPassword will be ignored).
+    # secret must contain the keys mariadb-root-password, mariadb-replication-password and mariadb-password
+    existingSecret: ""
 
   architecture: standalone
 
@@ -288,16 +294,27 @@ mariadb:
 
 ##
 ## PostgreSQL chart configuration
-## for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+## for more options see https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 ##
 postgresql:
   enabled: false
   global:
     postgresql:
+      # global.postgresql.auth overrides postgresql.auth 
       auth:
         username: nextcloud
         password: changeme
         database: nextcloud
+        # Name of existing secret to use for PostgreSQL credentials.
+        # auth.postgresPassword, auth.password, and auth.replicationPassword will be ignored and picked up from this secret.
+        # secret might also contains the key ldap-password if LDAP is enabled.
+        # ldap.bind_password will be ignored and picked from this secret in this case.
+        existingSecret: ""
+        # Names of keys in existing secret to use for PostgreSQL credentials
+        secretKeys:
+          adminPasswordKey: ""
+          userPasswordKey: ""
+          replicationPasswordKey: ""
   primary:
     persistence:
       enabled: false
@@ -307,7 +324,7 @@ postgresql:
 
 ##
 ## Redis chart configuration
-## for more options see https://github.com/bitnami/charts/tree/master/bitnami/redis
+## for more options see https://github.com/bitnami/charts/tree/main/bitnami/redis
 ##
 
 redis:
@@ -315,6 +332,11 @@ redis:
   auth:
     enabled: true
     password: 'changeme'
+    # name of an existing secret with Redis® credentials (instead of auth.password), must be created ahead of time
+    existingSecret: ""
+    # Password key to be retrieved from existing secret
+    existingSecretPasswordKey: ""
+
 
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron


### PR DESCRIPTION
# Pull Request

## Description of the change

Adding `exsitingSecret` parameters for MariaDB, PostgreSQL, and Redis.

Also updating docs to:
-  make it easier to link to sections of the configuration by separating out:
  - database config params
    - added new exsitingSecret params for both mariadb/postgres
  - persistence config params
  - metrics config params
  - add redis existingSecret params
- update supported versions of k8s (we can't support 1.10-1.19 as they are [not even in support by k8s anymore](https://kubernetes.io/releases/))
- update/add links to bitnami helm charts (they use main instead of master branch now)

## Benefits

Gives README a much needed face lift to make it easier to find stuff. Allows people to use existing secrets by default for all our services.

## Possible drawbacks

🤷 

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- closes #350

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md