### PR TITLE
Set DB name and host via external secret

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.12
+version: 3.5.13
 appVersion: 26.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -190,6 +190,8 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `externalDatabase.existingSecret.secretName`                         | Name of the existing secret                                                            | `nil`           |
 | `externalDatabase.existingSecret.usernameKey`                        | Name of the key that contains the username                                             | `nil`           |
 | `externalDatabase.existingSecret.passwordKey`                        | Name of the key that contains the password                                             | `nil`           |
+| `externalDatabase.existingSecret.hostKey`                            | Name of the key that contains the database hostname or IP address                      | `nil`           |
+| `externalDatabase.existingSecret.databaseKey`                        | Name of the key that contains the database name                                        | `nil`           |
 | `mariadb.enabled`                                                    | Whether to use the MariaDB chart                                                       | `false`         |
 | `mariadb.auth.database`                                              | Database name to create                                                                | `nextcloud`     |
 | `mariadb.auth.username`                                              | Database user to create                                                                | `nextcloud`     |

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -110,8 +110,21 @@ Create environment variables used to configure the nextcloud container as well a
 {{- else }}
   {{- if eq .Values.externalDatabase.type "postgresql" }}
 - name: POSTGRES_HOST
+  {{- if .Values.externalDatabase.existingSecret.hostKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+      key: {{ .Values.externalDatabase.existingSecret.hostKey }}
+  {{- else }}
   value: {{ .Values.externalDatabase.host | quote }}
+  {{- end }}
 - name: POSTGRES_DB
+  {{- if .Values.externalDatabase.existingSecret.databaseKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+      key: {{ .Values.externalDatabase.existingSecret.databaseKey }}
+  {{- else }}
   value: {{ .Values.externalDatabase.database | quote }}
 - name: POSTGRES_USER
   valueFrom:
@@ -125,9 +138,23 @@ Create environment variables used to configure the nextcloud container as well a
       key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
   {{- else }}
 - name: MYSQL_HOST
+  {{- if .Values.externalDatabase.existingSecret.hostKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+      key: {{ .Values.externalDatabase.existingSecret.hostKey }}
+  {{- else }}
   value: {{ .Values.externalDatabase.host | quote }}
+  {{- end }}
 - name: MYSQL_DATABASE
+  {{- if .Values.externalDatabase.existingSecret.databaseKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+      key: {{ .Values.externalDatabase.existingSecret.databaseKey }}
+  {{- else }}
   value: {{ .Values.externalDatabase.database | quote }}
+  {{- end }}
 - name: MYSQL_USER
   valueFrom:
     secretKeyRef:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -126,6 +126,7 @@ Create environment variables used to configure the nextcloud container as well a
       key: {{ .Values.externalDatabase.existingSecret.databaseKey }}
   {{- else }}
   value: {{ .Values.externalDatabase.database | quote }}
+  {{- end }}
 - name: POSTGRES_USER
   valueFrom:
     secretKeyRef:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -261,6 +261,8 @@ externalDatabase:
     # secretName: nameofsecret
     # usernameKey: db-username
     # passwordKey: db-password
+    # hostKey: db-hostname-or-ip
+    # databaseKey: db-name
 
 ##
 ## MariaDB chart configuration


### PR DESCRIPTION
Hi everyone, thanks for maintaining this useful Helm chart!

I'm using the [DB operator](https://github.com/kloeckner-i/db-operator/blob/master/docs/creatingdatabases.md) to automatically provision databases within my cluster.
It works very similar to Cert-Manager: you create a `Database` CR (instead of a `Certificate` CR) and the operator generates a Secret that contains the connection details for the database, like this:

```yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    created-by: db-operator
  name: nextcloud-db-credentials
type: Opaque
data:
  DB: << base64 encoded database name (generated by db operator) >>
  PASSWORD: << base64 encoded password (generated by db operator) >>
  USER: << base64 encoded user name (generated by db operator) >>
  HOST: << base64 encoded hostname (generated by db operator) >>
```

For this purpose, I would like to be able to also inject external database hostnames and names via a Secret (instead of passing them through the chart parameters).
This patch enables that functionality.