### PR TITLE
Clarify the behavior of "internalDatabase" setting

### DIFF
--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -228,7 +228,12 @@ nginx:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
+##
+## Internal sqlite database configuration
+##
 internalDatabase:
+  ## Wether to use the sqlite database. This takes precedence on other database settings
+  ## and must be false to use any other database type
   enabled: true
   name: nextcloud
 


### PR DESCRIPTION
Clarify that internalDatabase must be enabled: false to activate other databases in nextcloud config. Simply enabling mariadb, external or postgres database will not actually configure nextcloud to use it unless internalDatabase.enabled is false.

# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Only some clarifying comments

## Benefits

<!-- What benefits will be realized by the code change? -->
Saves some confusion that requires newcomers to go and read the templates to understand what the internalDatabase setting actually does

## Possible drawbacks

<!-- Describe any known limitations with your change -->
Adds 4 lines of comments in values.yaml, makes for a longer file, uses more space in the git repo and every clone. Should not cause too many issues in this world where terabytes of data is cheap.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes my nextcloud deployment that had a mariadb database running but was still using the sqlite database since I thought that "internalDatabase" could mean a database controlled by the helm chart, since "externalDatabase" means an external mysql/postgres database running outstide of the chart.

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
I'm kind of having fun writing way too much information about this 4 line comment only change. But if you want some additional information I think I may take the time to rename the "internalDatabase" setting to something that depicts more obviously that this setting is the master setting that controls the sqlite database. Or better yet, have a setting that makes more explicit that it is controlling nextcloud database connection configuration.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
