### PR TITLE
Match X-Robots-Tag recommendation in Nextcloud docs

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.4
+version: 3.5.5
 appVersion: 26.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -71,13 +71,13 @@ data:
             #pagespeed off;
 
             # HTTP response headers borrowed from Nextcloud `.htaccess`
-            add_header Referrer-Policy                      "no-referrer"   always;
-            add_header X-Content-Type-Options               "nosniff"       always;
-            add_header X-Download-Options                   "noopen"        always;
-            add_header X-Frame-Options                      "SAMEORIGIN"    always;
-            add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-            add_header X-Robots-Tag                         "none"          always;
-            add_header X-XSS-Protection                     "1; mode=block" always;
+            add_header Referrer-Policy                      "no-referrer"       always;
+            add_header X-Content-Type-Options               "nosniff"           always;
+            add_header X-Download-Options                   "noopen"            always;
+            add_header X-Frame-Options                      "SAMEORIGIN"        always;
+            add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+            add_header X-Robots-Tag                         "noindex, nofollow" always;
+            add_header X-XSS-Protection                     "1; mode=block"     always;
 
             # Remove X-Powered-By, which is an information leak
             fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
# Pull Request

## Description of the change

The [latest Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html) suggests setting `X-Robots-Tag` to `noindex, nofollow`. This changes the nginx configuration to align with that recommendation.

More context: https://github.com/nextcloud/server/issues/37357

Specifically, this explanation: https://github.com/nextcloud/server/issues/37357#issuecomment-1481235495

## Benefits

Prior to this change, someone who is following the Nextcloud documentation to set up their instance may set their nginx reverse proxy to add the `X-Robots-Tag: noindex, nofollow` header. Then their Nextcloud instance still generates the following warning even though they followed the documentation:

> The "X-Robots-Tag" HTTP header is not set to "noindex, nofollow". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.

This is because the Helm chart's included nginx instance still adds `X-Robots-Tag: none`.

## Possible drawbacks

I'm unsure if older Nextcloud installations will then start to complain that the older recommendation of `X-Robots-Tag: none` isn't implemented.

## Applicable issues

N/A

## Additional information

N/A

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
