### PR TITLE
[feat]: support configuration of loadBalancerClass and externalTrafficPolicy

### DIFF
--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -10,18 +10,18 @@ metadata:
     app.kubernetes.io/component: app
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.externalTrafficPolicy }}
+  {{- if and .Values.service.externalTrafficPolicy (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort"))}}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
-  {{- end }}
-  {{- if and .Values.service.loadBalancerClass (eq .Values.service.type "LoadBalancer") }}
-  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ default "" .Values.service.loadBalancerClass }}
   {{- end }}
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- end }}
   ports:
   - port: {{ .Values.service.port }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: app
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -16,6 +16,10 @@ spec:
   {{- if and .Values.service.loadBalancerClass (eq .Values.service.type "LoadBalancer") }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass }}
   {{- end }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if and .Values.service.loadBalancerClass (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -344,6 +344,7 @@ service:
   port: 8080
   loadBalancerIP: nil
   # loadBalancerClass:
+  # loadBalancerSourceRanges: []
   nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -343,6 +343,7 @@ service:
   type: ClusterIP
   port: 8080
   loadBalancerIP: nil
+  # loadBalancerClass:
   nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -341,6 +341,7 @@ cronjob:
 
 service:
   type: ClusterIP
+  # externalTrafficPolicy:
   port: 8080
   loadBalancerIP: nil
   # loadBalancerClass:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -341,11 +341,11 @@ cronjob:
 
 service:
   type: ClusterIP
-  # externalTrafficPolicy:
+  externalTrafficPolicy: nil
   port: 8080
   loadBalancerIP: nil
-  # loadBalancerClass:
-  # loadBalancerSourceRanges: []
+  loadBalancerClass: nil
+  loadBalancerSourceRanges: []
   nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims


### PR DESCRIPTION
# Pull Request

## Description of the change

This PullRequest extends the configuration of the k8s service for nextcloud setups running with metallb on prem. The problem is, if multiple k8s nodes are running the sourceIP of the client will be masked by the ip of the k8s nodes, because the traffic will be forwarded - node hopping. To avoid this behavior the externalTrafficPolicy can be set to Local. This property is currently missing. 

Furthermore, if on prem are multiple loadbalancers are installed it is not possible to specify explicit a different as the default.

## Benefits

The bruteforce protection mechanism works for on prem installations with metallb correctly, if externalTrafficPolicy is set to Local. Otherwise will be blocked the NodeIP and all users are affected by blocking one user.

## Documentation

https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer
