### PR TITLE
Update helm/chart-releaser-action `v1.4.1` -> `v1.5`; relax requirements for patch versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0        
+          fetch-depth: 0
 
       - name: Install Helm
         uses: azure/setup-helm@v3.1

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,12 +3,11 @@ name: Lint and Test Charts
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - '.github/**'
       - 'charts/**/README.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
       - 'CODE_OF_CONDUCT.md'
+      - 'LICENSE'
+      - 'README.md'
 
 jobs:
   lint-test:
@@ -17,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0        
 
       - name: Install Helm
         uses: azure/setup-helm@v3.1
@@ -29,7 +28,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.3
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -45,7 +44,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.4
         with:
           install_local_path_provisioner: true
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_repo_url: https://nextcloud.github.io/helm
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,10 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'README.md'
+      - '.github/**'
       - 'charts/**/README.md'
       - 'LICENSE'
+      - 'README.md'
 
 jobs:
   release:
@@ -36,15 +37,13 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3.1
         with:
-          version: v3.6.3
+          version: v3.6
 
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        with:
-          charts_repo_url: https://nextcloud.github.io/helm
+        uses: helm/chart-releaser-action@v1.5
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull Request

## Description of the change

This updates the `helm/chart-releaser-action` in our github workflow from `v1.4.1` to `v1.5`. I've also dropped the patch versions, so that we can always make sure we have patch releases up to date, and then we can still be strict when it comes to minor and major releases.

## Benefits

Keeps our workflows up to date, for security reasons and potential deprecations.

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #329 

## Additional information

Didn't update chart version, because it shouldn't need to be for the github workflow updates

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
