### PR TITLE
add docker package ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -9,4 +9,9 @@ updates:
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/charts/nextcloud"
+    schedule:
       interval: "daily"


### PR DESCRIPTION
# Pull Request

## Description of the change

Add docker to package ecosystems that dependabot supports

Should work on helm charts as per the note in [this section of the docs at the bottom](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem):

> [1] Dependabot can update Docker image tags in Kubernetes manifests. Add an entry to the Docker package-ecosystem element of your dependabot.yml file for each directory containing a Kubernetes manifest which references Docker image tags. Kubernetes manifests can be Kubernetes Deployment YAML files or Helm charts. For information about configuring your dependabot.yml file for docker, see "package-ecosystem" in "[Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)."

## Benefits

This will catch if we let the nextcloud image (or other images) get out of date and open a PR based on that.

## Possible drawbacks

more PRs to review

## Applicable issues

none

## Additional information

none

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
