### PR TITLE
add default image.flavor to values.yaml

### DIFF
--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -39,18 +39,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-Create image name that is used in the deployment
-*/}}
-{{- define "nextcloud.image" -}}
-{{- if .Values.image.tag -}}
-{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
-{{- else -}}
-{{- printf "%s:%s-%s" .Values.image.repository .Chart.AppVersion (default "apache" .Values.image.flavor) -}}
-{{- end -}}
-{{- end -}}
-
-
 {{- define "nextcloud.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
@@ -60,7 +48,6 @@ Create image name that is used in the deployment
 {{- print "networking.k8s.io/v1" -}}
 {{- end }}
 {{- end -}}
-
 
 {{/*
 Create environment variables used to configure the nextcloud container as well as the cron sidecar container.

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: {{ include "nextcloud.image" . }}
+        {{- if .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        {{ else }}
+        image: {{ .Values.image.repository }}:{{ .Chart.AppVersion }}-{{( .Values.image.flavor }} 
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.lifecycle }}
         lifecycle:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -3,7 +3,10 @@
 ##
 image:
   repository: nextcloud
-  # tag: 24.0.3-apache
+  # flavor can also be set to fpm if you'd like to use nginx instead of apache with nextcloud
+  flavor: apache
+  # tag defaults to current app version in helm chart + default flavor (apache)
+  # tag: 26.0.0-apache
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName


### PR DESCRIPTION
# Pull Request

## Description of the change

adds default `image.flavor` because we need it for a simplified deployment template, so we can remove this part of helpers.tpl and maybe fix an issue where the `image.tag` needs to be nested under `nextcloud`.

## Benefits

<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #336

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
