### PR TITLE
Fix helm GitHub Actions version constraints and bump to latest

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -28,7 +28,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -44,7 +44,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4
+        uses: helm/kind-action@v1.5.0
         with:
           install_local_path_provisioner: true
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,6 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull Request

## Description of the change

Fixed because:
- helm/kind-action does not create tags for minor versions with no patch version:
  https://github.com/helm/kind-action/tags
- helm/chart-testing-action does not create tags for minor versions with no patch version:
  https://github.com/helm/chart-testing-action/tags
- helm/chart-releaser does not create tags for minor versions without patch version, so we can't relax this right now:
  https://github.com/helm/chart-releaser-action/tags

Looks like this is due to the helm org not releasing tags like `v1.5`, instead of only `v1.5.0`, unlike the [azure/setup-helm github action](https://github.com/Azure/setup-helm/tags), which _does_ tag for minor versions like `v3.5`.

Also bumped kind action version from `1.4` -> `1.5`.

## Benefits

Fixes the issues shown [here](https://github.com/nextcloud/helm/actions/runs/4659080092):

<img width="1070" alt="Screenshot 2023-04-10 at 18 28 58" src="https://user-images.githubusercontent.com/2389292/230946284-26c7374b-b186-49e3-b0d0-f5405e955b18.png">

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
