### PR TITLE
update security context values from string to int64

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.7
+version: 3.5.8
 appVersion: 26.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -191,19 +191,20 @@ nextcloud:
   #  - name: nfs
   #    mountPath: "/legacy_data"
 
-  # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
+  # Set securityContext parameters for the nextcloud CONTAINER only (will not affect nginx container).
+  # For example, you may need to define runAsNonRoot directive
   securityContext: {}
-  #   runAsUser: "33"
-  #   runAsGroup: "33"
+  #   runAsUser: 33
+  #   runAsGroup: 33
   #   runAsNonRoot: true
-  #   readOnlyRootFilesystem: true
+  #   readOnlyRootFilesystem: false
 
-  # Set securityContext parameters for the pod. For example, you may need to define runAsNonRoot directive
+  # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
   podSecurityContext: {}
-  #   runAsUser: "33"
-  #   runAsGroup: "33"
+  #   runAsUser: 33
+  #   runAsGroup: 33
   #   runAsNonRoot: true
-  #   readOnlyRootFilesystem: true
+  #   readOnlyRootFilesystem: false
 
 nginx:
   ## You need to set an fpm version of the image for nextcloud if you want to use nginx!
@@ -221,10 +222,11 @@ nginx:
 
   resources: {}
 
-  # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
+  # Set nginx container securityContext parameters. For example, you may need to define runAsNonRoot directive
   securityContext: {}
-  #   runAsUser: "82"
-  #   runAsGroup: "33"
+  # the nginx alpine container default user is 82
+  #   runAsUser: 82
+  #   runAsGroup: 33
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
@@ -356,8 +358,8 @@ cronjob:
     # preStopCommand: []
   # Set securityContext parameters. For example, you may need to define runAsNonRoot directive
   securityContext: {}
-  #   runAsUser: "33"
-  #   runAsGroup: "33"
+  #   runAsUser: 33
+  #   runAsGroup: 33
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
@@ -535,5 +537,5 @@ rbac:
     annotations: {}
 
 
-## @param securityContext @deprecated Use `nextcloud.podSecurityContext` instead
+## @param securityContext for nextcloud pod @deprecated Use `nextcloud.podSecurityContext` instead
 securityContext: {}


### PR DESCRIPTION
# Pull Request

## Description of the change

Updates default commented out security context values in values.yaml from `"33"` to `33`, and adds more description to comments.

## Benefits

Helps uses not get an error if they just uncomment the defaults for `*.securityContext`

## Possible drawbacks

🤷 

## Applicable issues

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md