### PR TITLE
Always `podSecurityContext.fsGroup` to `33`, even if nginx is enabled

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.11
+version: 3.6.0
 appVersion: 26.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -53,117 +53,122 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                            | Description                                                                            | Default                                      |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
-| `image.repository`                                                   | nextcloud Image name                                                                   | `nextcloud`                                  |
-| `image.flavor`                                                       | nextcloud Image type (Options: apache, fpm)                                            | `apache`                                     |
-| `image.tag`                                                          | nextcloud Image tag                                                                    | `{VERSION}`                                  |
-| `image.pullPolicy`                                                   | Image pull policy                                                                      | `IfNotPresent`                               |
-| `image.pullSecrets`                                                  | Specify image pull secrets                                                             | `nil`                                        |
-| `replicaCount`                                                       | Number of nextcloud pods to deploy                                                     | `1`                                          |
-| `ingress.className`                                                  | Name of the ingress class to use                                                       | `nil`                                        |
-| `ingress.enabled`                                                    | Enable use of ingress controllers                                                      | `false`                                      |
-| `ingress.servicePort`                                                | Ingress' backend servicePort                                                           | `http`                                       |
-| `ingress.annotations`                                                | An array of service annotations                                                        | `nil`                                        |
-| `ingress.labels`                                                     | An array of service labels                                                             | `nil`                                        |
-| `ingress.path`                                                       | The `Path` to use in Ingress' `paths`                                                  | `/`                                          |
-| `ingress.pathType`                                                   | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                                     |
-| `ingress.tls`                                                        | Ingress TLS configuration                                                              | `[]`                                         |
-| `nextcloud.host`                                                     | nextcloud host to create application URLs                                              | `nextcloud.kube.home`                        |
-| `nextcloud.username`                                                 | User of the application                                                                | `admin`                                      |
-| `nextcloud.password`                                                 | Application password                                                                   | `changeme`                                   |
-| `nextcloud.existingSecret.enabled`                                   | Whether to use an existing secret or not                                               | `false`                                      |
-| `nextcloud.existingSecret.secretName`                                | Name of the existing secret                                                            | `nil`                                        |
-| `nextcloud.existingSecret.usernameKey`                               | Name of the key that contains the username                                             | `nil`                                        |
-| `nextcloud.existingSecret.passwordKey`                               | Name of the key that contains the password                                             | `nil`                                        |
-| `nextcloud.existingSecret.smtpUsernameKey`                           | Name of the key that contains the SMTP username                                        | `nil`                                        |
-| `nextcloud.existingSecret.smtpPasswordKey`                           | Name of the key that contains the SMTP password                                        | `nil`                                        |
-| `nextcloud.update`                                                   | Trigger update if custom command is used                                               | `0`                                          |
-| `nextcloud.containerPort`                                            | Customize container port when not running as root                                      | `80`                                         |
-| `nextcloud.datadir`                                                  | nextcloud data dir location                                                            | `/var/www/html/data`                         |
-| `nextcloud.mail.enabled`                                             | Whether to enable/disable email settings                                               | `false`                                      |
-| `nextcloud.mail.fromAddress`                                         | nextcloud mail send from field                                                         | `nil`                                        |
-| `nextcloud.mail.domain`                                              | nextcloud mail domain                                                                  | `nil`                                        |
-| `nextcloud.mail.smtp.host`                                           | SMTP hostname                                                                          | `nil`                                        |
-| `nextcloud.mail.smtp.secure`                                         | SMTP connection `ssl` or empty                                                         | `''`                                         |
-| `nextcloud.mail.smtp.port`                                           | Optional SMTP port                                                                     | `nil`                                        |
-| `nextcloud.mail.smtp.authtype`                                       | SMTP authentication method                                                             | `LOGIN`                                      |
-| `nextcloud.mail.smtp.name`                                           | SMTP username                                                                          | `''`                                         |
-| `nextcloud.mail.smtp.password`                                       | SMTP password                                                                          | `''`                                         |
-| `nextcloud.configs`                                                  | Config files created in `/var/www/html/config`                                         | `{}`                                         |
-| `nextcloud.persistence.subPath`                                      | Set the subPath for nextcloud to use in volume                                         | `nil`                                        |
-| `nextcloud.phpConfigs`                                               | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                                         |
-| `nextcloud.defaultConfigs.\.htaccess`                                | Default .htaccess to protect `/var/www/html/config`                                    | `true`                                       |
-| `nextcloud.defaultConfigs.redis\.config\.php`                        | Default Redis configuration                                                            | `true`                                       |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`           | Default Apache configuration for rewrite urls                                          | `true`                                       |
-| `nextcloud.defaultConfigs.apcu\.config\.php`                         | Default configuration to define APCu as local cache                                    | `true`                                       |
-| `nextcloud.defaultConfigs.apps\.config\.php`                         | Default configuration for apps                                                         | `true`                                       |
-| `nextcloud.defaultConfigs.autoconfig\.php`                           | Default auto-configuration for databases                                               | `true`                                       |
-| `nextcloud.defaultConfigs.smtp\.config\.php`                         | Default configuration for smtp                                                         | `true`                                       |
-| `nextcloud.strategy`                                                 | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`                             |
-| `nextcloud.extraEnv`                                                 | specify additional environment variables                                               | `{}`                                         |
-| `nextcloud.extraSidecarContainers`                                   | specify additional sidecar containers                                                  | `[]`                                         |
-| `nextcloud.extraInitContainers`                                      | specify additional init containers                                                     | `[]`                                         |
-| `nextcloud.extraVolumes`                                             | specify additional volumes for the NextCloud pod                                       | `{}`                                         |
-| `nextcloud.extraVolumeMounts`                                        | specify additional volume mounts for the NextCloud pod                                 | `{}`                                         |
-| `nextcloud.securityContext`                                          | Optional security context for the NextCloud container                                  | `nil`                                        |
-| `nextcloud.podSecurityContext`                                       | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                                        |
-| `nginx.enabled`                                                      | Enable nginx (requires you use php-fpm image)                                          | `false`                                      |
-| `nginx.image.repository`                                             | nginx Image name                                                                       | `nginx`                                      |
-| `nginx.image.tag`                                                    | nginx Image tag                                                                        | `alpine`                                     |
-| `nginx.image.pullPolicy`                                             | nginx Image pull policy                                                                | `IfNotPresent`                               |
-| `nginx.config.default`                                               | Whether to use nextcloud's recommended nginx config                                    | `true`                                       |
-| `nginx.config.custom`                                                | Specify a custom config for nginx                                                      | `{}`                                         |
-| `nginx.resources`                                                    | nginx resources                                                                        | `{}`                                         |
-| `nginx.securityContext`                                              | Optional security context for the nginx container                                      | `nil`                                        |
-| `lifecycle.postStartCommand`                                         | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
-| `lifecycle.preStopCommand`                                           | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
-| `redis.enabled`                                                      | Whether to install/use redis for locking                                               | `false`                                      |
-| `redis.auth.enabled`                                                 | Whether to enable password authentication with redis                                   | `true`                                       |
-| `redis.auth.password`                                                | The password redis uses                                                                | `''`                                         |
-| `redis.auth.existingSecret`                                          | The name of an existing secret with Redis® credentials                                 | `''`                                         |
-| `redis.auth.existingSecretPasswordKey`                               | Password key to be retrieved from existing secret                                      | `''`                                         |
-| `cronjob.enabled`                                                    | Whether to enable/disable cronjob                                                      | `false`                                      |
-| `cronjob.lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
-| `cronjob.lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
-| `cronjob.resources`                                                  | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                                         |
-| `cronjob.securityContext`                                            | Optional security context for cronjob                                                  | `nil`                                        |
-| `service.type`                                                       | Kubernetes Service type                                                                | `ClusterIP`                                  |
-| `service.loadBalancerIP`                                             | LoadBalancerIp for service type LoadBalancer                                           | `nil`                                        |
-| `service.nodePort`                                                   | NodePort for service type NodePort                                                     | `nil`                                        |
-| `phpClientHttpsFix.enabled`                                          | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                                      |
-| `phpClientHttpsFix.protocol`                                         | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                                      |
-| `resources`                                                          | CPU/Memory resource requests/limits                                                    | `{}`                                         |
-| `rbac.enabled`                                                       | Enable Role and rolebinding for priveledged PSP                                        | `false`                                      |
-| `rbac.serviceaccount.create`                                         | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                                       |
-| `rbac.serviceaccount.name`                                           | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount`                   |
-| `rbac.serviceaccount.annotations`                                    | Serviceaccount annotations                                                             | `{}`                                         |
-| `livenessProbe.enabled`                                              | Turn on and off liveness probe                                                         | `true`                                       |
-| `livenessProbe.initialDelaySeconds`                                  | Delay before liveness probe is initiated                                               | `10`                                         |
-| `livenessProbe.periodSeconds`                                        | How often to perform the probe                                                         | `10`                                         |
-| `livenessProbe.timeoutSeconds`                                       | When the probe times out                                                               | `5`                                          |
-| `livenessProbe.failureThreshold`                                     | Minimum consecutive failures for the probe                                             | `3`                                          |
-| `livenessProbe.successThreshold`                                     | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `readinessProbe.enabled`                                             | Turn on and off readiness probe                                                        | `true`                                       |
-| `readinessProbe.initialDelaySeconds`                                 | Delay before readiness probe is initiated                                              | `10`                                         |
-| `readinessProbe.periodSeconds`                                       | How often to perform the probe                                                         | `10`                                         |
-| `readinessProbe.timeoutSeconds`                                      | When the probe times out                                                               | `5`                                          |
-| `readinessProbe.failureThreshold`                                    | Minimum consecutive failures for the probe                                             | `3`                                          |
-| `readinessProbe.successThreshold`                                    | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `startupProbe.enabled`                                               | Turn on and off startup probe                                                          | `false`                                      |
-| `startupProbe.initialDelaySeconds`                                   | Delay before readiness probe is initiated                                              | `30`                                         |
-| `startupProbe.periodSeconds`                                         | How often to perform the probe                                                         | `10`                                         |
-| `startupProbe.timeoutSeconds`                                        | When the probe times out                                                               | `5`                                          |
-| `startupProbe.failureThreshold`                                      | Minimum consecutive failures for the probe                                             | `30`                                         |
-| `startupProbe.successThreshold`                                      | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `hpa.enabled`                                                        | Boolean to create a HorizontalPodAutoscaler                                            | `false`                                      |
-| `hpa.cputhreshold`                                                   | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                                         |
-| `hpa.minPods`                                                        | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                                          |
-| `hpa.maxPods`                                                        | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                                         |
-| `deploymentLabels`                                                   | Labels to be added at 'deployment' level                                               | not set                                      |
-| `deploymentAnnotations`                                              | Annotations to be added at 'deployment' level                                          | not set                                      |
-| `podLabels`                                                          | Labels to be added at 'pod' level                                                      | not set                                      |
-| `podAnnotations`                                                     | Annotations to be added at 'pod' level                                                 | not set                                      |
+| Parameter                                                   | Description                                                                            | Default                          |
+|-------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------|
+| `image.repository`                                          | nextcloud Image name                                                                   | `nextcloud`                      |
+| `image.flavor`                                              | nextcloud Image type (Options: apache, fpm)                                            | `apache`                         |
+| `image.tag`                                                 | nextcloud Image tag                                                                    | `{VERSION}`                      |
+| `image.pullPolicy`                                          | Image pull policy                                                                      | `IfNotPresent`                   |
+| `image.pullSecrets`                                         | Specify image pull secrets                                                             | `nil`                            |
+| `replicaCount`                                              | Number of nextcloud pods to deploy                                                     | `1`                              |
+| `ingress.className`                                         | Name of the ingress class to use                                                       | `nil`                            |
+| `ingress.enabled`                                           | Enable use of ingress controllers                                                      | `false`                          |
+| `ingress.servicePort`                                       | Ingress' backend servicePort                                                           | `http`                           |
+| `ingress.annotations`                                       | An array of service annotations                                                        | `nil`                            |
+| `ingress.labels`                                            | An array of service labels                                                             | `nil`                            |
+| `ingress.path`                                              | The `Path` to use in Ingress' `paths`                                                  | `/`                              |
+| `ingress.pathType`                                          | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                         |
+| `ingress.tls`                                               | Ingress TLS configuration                                                              | `[]`                             |
+| `nextcloud.host`                                            | nextcloud host to create application URLs                                              | `nextcloud.kube.home`            |
+| `nextcloud.username`                                        | User of the application                                                                | `admin`                          |
+| `nextcloud.password`                                        | Application password                                                                   | `changeme`                       |
+| `nextcloud.existingSecret.enabled`                          | Whether to use an existing secret or not                                               | `false`                          |
+| `nextcloud.existingSecret.secretName`                       | Name of the existing secret                                                            | `nil`                            |
+| `nextcloud.existingSecret.usernameKey`                      | Name of the key that contains the username                                             | `nil`                            |
+| `nextcloud.existingSecret.passwordKey`                      | Name of the key that contains the password                                             | `nil`                            |
+| `nextcloud.existingSecret.smtpUsernameKey`                  | Name of the key that contains the SMTP username                                        | `nil`                            |
+| `nextcloud.existingSecret.smtpPasswordKey`                  | Name of the key that contains the SMTP password                                        | `nil`                            |
+| `nextcloud.update`                                          | Trigger update if custom command is used                                               | `0`                              |
+| `nextcloud.containerPort`                                   | Customize container port when not running as root                                      | `80`                             |
+| `nextcloud.datadir`                                         | nextcloud data dir location                                                            | `/var/www/html/data`             |
+| `nextcloud.mail.enabled`                                    | Whether to enable/disable email settings                                               | `false`                          |
+| `nextcloud.mail.fromAddress`                                | nextcloud mail send from field                                                         | `nil`                            |
+| `nextcloud.mail.domain`                                     | nextcloud mail domain                                                                  | `nil`                            |
+| `nextcloud.mail.smtp.host`                                  | SMTP hostname                                                                          | `nil`                            |
+| `nextcloud.mail.smtp.secure`                                | SMTP connection `ssl` or empty                                                         | `''`                             |
+| `nextcloud.mail.smtp.port`                                  | Optional SMTP port                                                                     | `nil`                            |
+| `nextcloud.mail.smtp.authtype`                              | SMTP authentication method                                                             | `LOGIN`                          |
+| `nextcloud.mail.smtp.name`                                  | SMTP username                                                                          | `''`                             |
+| `nextcloud.mail.smtp.password`                              | SMTP password                                                                          | `''`                             |
+| `nextcloud.configs`                                         | Config files created in `/var/www/html/config`                                         | `{}`                             |
+| `nextcloud.persistence.subPath`                             | Set the subPath for nextcloud to use in volume                                         | `nil`                            |
+| `nextcloud.phpConfigs`                                      | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                             |
+| `nextcloud.defaultConfigs.\.htaccess`                       | Default .htaccess to protect `/var/www/html/config`                                    | `true`                           |
+| `nextcloud.defaultConfigs.redis\.config\.php`               | Default Redis configuration                                                            | `true`                           |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`  | Default Apache configuration for rewrite urls                                          | `true`                           |
+| `nextcloud.defaultConfigs.apcu\.config\.php`                | Default configuration to define APCu as local cache                                    | `true`                           |
+| `nextcloud.defaultConfigs.apps\.config\.php`                | Default configuration for apps                                                         | `true`                           |
+| `nextcloud.defaultConfigs.autoconfig\.php`                  | Default auto-configuration for databases                                               | `true`                           |
+| `nextcloud.defaultConfigs.smtp\.config\.php`                | Default configuration for smtp                                                         | `true`                           |
+| `nextcloud.strategy`                                        | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`                 |
+| `nextcloud.extraEnv`                                        | specify additional environment variables                                               | `{}`                             |
+| `nextcloud.extraSidecarContainers`                          | specify additional sidecar containers                                                  | `[]`                             |
+| `nextcloud.extraInitContainers`                             | specify additional init containers                                                     | `[]`                             |
+| `nextcloud.extraVolumes`                                    | specify additional volumes for the NextCloud pod                                       | `{}`                             |
+| `nextcloud.extraVolumeMounts`                               | specify additional volume mounts for the NextCloud pod                                 | `{}`                             |
+| `nextcloud.securityContext`                                 | Optional security context for the NextCloud container                                  | `{}`                             |
+| `nextcloud.securityContext.runAsUser`                       | Optional security context for the NextCloud container to run as UID                    | `nil`                            |
+| `nextcloud.securityContext.runAsGroup`                      | Optional security context for the NextCloud container to run as GID                    | `nil`                            |
+| `nextcloud.securityContext.runAsNonRoot`                    | Optional security context for the NextCloud container to not run as root               | `nil`                            |
+| `nextcloud.securityContext.allowPrivilegeEscalation`        | Optional security context for the NextCloud container to limit Privilege Escalation    | `nil`                            |
+| `nextcloud.podSecurityContext`                              | Optional security context for the NextCloud pod (applies to all containers in the pod) | `{fsgroup: 33}`                  |
+| `nextcloud.podSecurityContext.fsGroup`                      | special supplemental group that applies to all containers in the NextCloud pod         | `33`                             |
+| `nginx.enabled`                                             | Enable nginx (requires you use php-fpm image)                                          | `false`                          |
+| `nginx.image.repository`                                    | nginx Image name                                                                       | `nginx`                          |
+| `nginx.image.tag`                                           | nginx Image tag                                                                        | `alpine`                         |
+| `nginx.image.pullPolicy`                                    | nginx Image pull policy                                                                | `IfNotPresent`                   |
+| `nginx.config.default`                                      | Whether to use nextcloud's recommended nginx config                                    | `true`                           |
+| `nginx.config.custom`                                       | Specify a custom config for nginx                                                      | `{}`                             |
+| `nginx.resources`                                           | nginx resources                                                                        | `{}`                             |
+| `nginx.securityContext`                                     | Optional security context for the nginx container                                      | `nil`                            |
+| `lifecycle.postStartCommand`                                | Specify deployment lifecycle hook postStartCommand                                     | `nil`                            |
+| `lifecycle.preStopCommand`                                  | Specify deployment lifecycle hook preStopCommand                                       | `nil`                            |
+| `redis.enabled`                                             | Whether to install/use redis for locking                                               | `false`                          |
+| `redis.auth.enabled`                                        | Whether to enable password authentication with redis                                   | `true`                           |
+| `redis.auth.password`                                       | The password redis uses                                                                | `''`                             |
+| `redis.auth.existingSecret`                                 | The name of an existing secret with Redis® credentials                                 | `''`                             |
+| `redis.auth.existingSecretPasswordKey`                      | Password key to be retrieved from existing secret                                      | `''`                             |
+| `cronjob.enabled`                                           | Whether to enable/disable cronjob                                                      | `false`                          |
+| `cronjob.lifecycle.postStartCommand`                        | Specify deployment lifecycle hook postStartCommand                                     | `nil`                            |
+| `cronjob.lifecycle.preStopCommand`                          | Specify deployment lifecycle hook preStopCommand                                       | `nil`                            |
+| `cronjob.resources`                                         | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                             |
+| `cronjob.securityContext`                                   | Optional security context for cronjob                                                  | `nil`                            |
+| `service.type`                                              | Kubernetes Service type                                                                | `ClusterIP`                      |
+| `service.loadBalancerIP`                                    | LoadBalancerIp for service type LoadBalancer                                           | `nil`                            |
+| `service.nodePort`                                          | NodePort for service type NodePort                                                     | `nil`                            |
+| `phpClientHttpsFix.enabled`                                 | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                          |
+| `phpClientHttpsFix.protocol`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                          |
+| `resources`                                                 | CPU/Memory resource requests/limits                                                    | `{}`                             |
+| `rbac.enabled`                                              | Enable Role and rolebinding for priveledged PSP                                        | `false`                          |
+| `rbac.serviceaccount.create`                                | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                           |
+| `rbac.serviceaccount.name`                                  | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount`       |
+| `rbac.serviceaccount.annotations`                           | Serviceaccount annotations                                                             | `{}`                             |
+| `livenessProbe.enabled`                                     | Turn on and off liveness probe                                                         | `true`                           |
+| `livenessProbe.initialDelaySeconds`                         | Delay before liveness probe is initiated                                               | `10`                             |
+| `livenessProbe.periodSeconds`                               | How often to perform the probe                                                         | `10`                             |
+| `livenessProbe.timeoutSeconds`                              | When the probe times out                                                               | `5`                              |
+| `livenessProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                             | `3`                              |
+| `livenessProbe.successThreshold`                            | Minimum consecutive successes for the probe                                            | `1`                              |
+| `readinessProbe.enabled`                                    | Turn on and off readiness probe                                                        | `true`                           |
+| `readinessProbe.initialDelaySeconds`                        | Delay before readiness probe is initiated                                              | `10`                             |
+| `readinessProbe.periodSeconds`                              | How often to perform the probe                                                         | `10`                             |
+| `readinessProbe.timeoutSeconds`                             | When the probe times out                                                               | `5`                              |
+| `readinessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                             | `3`                              |
+| `readinessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                            | `1`                              |
+| `startupProbe.enabled`                                      | Turn on and off startup probe                                                          | `false`                          |
+| `startupProbe.initialDelaySeconds`                          | Delay before readiness probe is initiated                                              | `30`                             |
+| `startupProbe.periodSeconds`                                | How often to perform the probe                                                         | `10`                             |
+| `startupProbe.timeoutSeconds`                               | When the probe times out                                                               | `5`                              |
+| `startupProbe.failureThreshold`                             | Minimum consecutive failures for the probe                                             | `30`                             |
+| `startupProbe.successThreshold`                             | Minimum consecutive successes for the probe                                            | `1`                              |
+| `hpa.enabled`                                               | Boolean to create a HorizontalPodAutoscaler                                            | `false`                          |
+| `hpa.cputhreshold`                                          | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                             |
+| `hpa.minPods`                                               | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                              |
+| `hpa.maxPods`                                               | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                             |
+| `deploymentLabels`                                          | Labels to be added at 'deployment' level                                               | not set                          |
+| `deploymentAnnotations`                                     | Annotations to be added at 'deployment' level                                          | not set                          |
+| `podLabels`                                                 | Labels to be added at 'pod' level                                                      | not set                          |
+| `podAnnotations`                                            | Annotations to be added at 'pod' level                                                 | not set                          |
 
 
 ### Database Configurations
@@ -412,3 +417,16 @@ persistence:
   enabled: true
   accessMode: ReadWriteMany
 ```
+
+## Security Contexts
+
+These are all the [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core) objects you can configure for this helm chart:
+
+| config option               | Description                                                           |
+|:---------------------------:|:----------------------------------------------------------------------|
+| `nextcloud.securityContext` | Optional SecurityContext for the NextCloud container                  |
+| `cronjob.securityContext`   | Optional SecurityContext for cronjob                                  |
+| `nginx.securityContext`     | Optional SecurityContext for the nginx container in the nextcloud pod |
+
+You can also set the [PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core) for the nextcloud pod.
+By default, `nextcloud.podSecurityContext.fsGroup` is set to `33` (the `www-data` user's GID) by default. Set this to `82` if you're using an alpine nextcloud image.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -2,6 +2,8 @@
 
 [nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
 
+> **Warning**: Please see [Breaking Changes](#breaking-changes) before upgrading this helm chart!
+
 ## TL;DR;
 
 ```console
@@ -429,4 +431,11 @@ These are all the [SecurityContext](https://kubernetes.io/docs/reference/generat
 | `nginx.securityContext`     | Optional SecurityContext for the nginx container in the nextcloud pod |
 
 You can also set the [PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core) for the nextcloud pod.
-By default, `nextcloud.podSecurityContext.fsGroup` is set to `33` (the `www-data` user's GID) by default. Set this to `82` if you're using an alpine nextcloud image.
+By default, `nextcloud.podSecurityContext.fsGroup` is set to `33` (the `www-data` user's GID). Set this to `82` if you're using an alpine nextcloud image.
+
+
+# Breaking Changes
+Note changes that may cause disruptions between helm chart upgrades.
+
+## `3.5.11` -> `3.6.0`
+By default, `nextcloud.podSecurityContext.fsGroup` is set to `33` (the `www-data` user's GID). Set this to `82` if you're using an alpine nextcloud image.

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -335,13 +335,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- else }}
-        {{- if .Values.nginx.enabled }}
-        # Will mount configuration files as www-data (id: 82) for nextcloud
-        fsGroup: 82
-        {{- else }}
-        # Will mount configuration files as www-data (id: 33) for nextcloud
-        fsGroup: 33
-        {{- end }}
+        # this is deprecated and will be removed in a future release - use nextcloud.podSecurityContext instead
         {{- if .Values.securityContext }}
           {{- with .Values.securityContext }}
             {{- toYaml . | nindent 8 }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -191,20 +191,25 @@ nextcloud:
   #  - name: nfs
   #    mountPath: "/legacy_data"
 
-  # Set securityContext parameters for the nextcloud CONTAINER only (will not affect nginx container).
-  # For example, you may need to define runAsNonRoot directive
+  # Set SecurityContext parameters for the nextcloud CONTAINER only (will not affect nginx container)
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
   securityContext: {}
-  #   runAsUser: 33
-  #   runAsGroup: 33
-  #   runAsNonRoot: true
-  #   readOnlyRootFilesystem: false
+    # if using a nextcloud image with alpine as the base image, change 33 to 82 for both runAsUser and runAsGroup
+    # runAsUser: 33
+    # runAsGroup: 33
+    # runAsNonRoot: true
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: false
 
-  # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
-  podSecurityContext: {}
-  #   runAsUser: 33
-  #   runAsGroup: 33
-  #   runAsNonRoot: true
-  #   readOnlyRootFilesystem: false
+  # Set podSecurityContext parameters for all containers in the nextcloud pod, defaults to fsGroup `33`
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podsecuritycontext-v1-core
+  podSecurityContext:
+    # Change to 82 if you're using an alpine base image for the nextcloud container
+    fsGroup: 33
+    # runAsUser: 33
+    # runAsGroup: 33
+    # runAsNonRoot: true
+    # readOnlyRootFilesystem: false
 
 nginx:
   ## You need to set an fpm version of the image for nextcloud if you want to use nginx!
@@ -223,8 +228,9 @@ nginx:
   resources: {}
 
   # Set nginx container securityContext parameters. For example, you may need to define runAsNonRoot directive
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
   securityContext: {}
-  # the nginx alpine container default user is 82
+  # the nginx:alpine container www-data user is 82
   #   runAsUser: 82
   #   runAsGroup: 33
   #   runAsNonRoot: true
@@ -529,7 +535,6 @@ metrics:
     ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
-
 
 rbac:
   enabled: false


### PR DESCRIPTION
# Pull Request

## Description of the change

Changes default fsGroup to be `33`. In all `apache` and regular `fpm`, the `www-data` user is `33`.

The `www-data` user is `82` in all alpine images (including nginx), so I added a note in the README about it.

Previously we relied on if the user was using `nginx.enabled` which is alpine by default, but using `nginx:alpine` doesn't mean you're using `nextcloud:fpm-alpine`.

## Benefits

If someone uses `image.flavor` of `apache` or `fpm`, the `fsGroup` should be `33` by default.

## Possible drawbacks

If you used an alpine image, you will now have to manually set `nextcloud.podSecurityContext.fsGroup` to be `82` in your values.yaml.

## Applicable issues

- partially fixes #335

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
