### PR TITLE
Update Run chart-testing (list-changed) GHA step to use $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -33,9 +33,9 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION


# Pull Request

## Description of the change
set-output commands are deprecated so it's giving us [warnings](https://github.com/nextcloud/helm/actions/runs/4780495468) in the GHA logs:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I've updated those commands we were using to the recommendations from the [helm/chart-testing-action example](https://github.com/helm/chart-testing-action#example-workflow).

## Benefits

Removes warnings in the log.

## Possible drawbacks

None that I can see here.

## Applicable issues
none

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
