### PR TITLE
Set default for nextcloud.containerPort in values.yaml and update YAML templates to use it everywhere

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.11
+version: 3.5.12
 appVersion: 26.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -76,14 +76,14 @@ spec:
         {{- if not .Values.nginx.enabled }}
         ports:
         - name: http
-          containerPort: {{ .Values.nextcloud.containerPort | default "80" }}
+          containerPort: {{ .Values.nextcloud.containerPort }}
           protocol: TCP
         {{- end }}
         {{- if and .Values.livenessProbe.enabled (not .Values.nginx.enabled) }}
         livenessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port:  {{ .Values.nextcloud.containerPort }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -97,7 +97,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port:  {{ .Values.nextcloud.containerPort }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -111,7 +111,7 @@ spec:
         startupProbe:
           httpGet:
             path: /status.php
-            port: http
+            port:  {{ .Values.nextcloud.containerPort }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}
@@ -171,7 +171,7 @@ spec:
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         ports:
         - name: http
-          containerPort: {{ .Values.nextcloud.containerPort | default "80" }}
+          containerPort: {{ .Values.nextcloud.containerPort }}
           protocol: TCP
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -191,7 +191,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /status.php
-            port: http
+            port: {{ .Values.nextcloud.containerPort }}
             httpHeaders:
             - name: Host
               value: {{ .Values.nextcloud.host | quote }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: http
+    targetPort: {{ .Values.nextcloud.containerPort }}
     protocol: TCP
     name: http
     {{- if eq .Values.service.type "NodePort" }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -85,7 +85,7 @@ nextcloud:
     # smtpPasswordKey: smtp-password
   update: 0
   # If web server is not binding default port, you can define it
-  # containerPort: 8080
+  containerPort: 80
   datadir: /var/www/html/data
   persistence:
     subPath:


### PR DESCRIPTION
# Pull Request

## Description of the change

Reworked this PR to include other changes from two other PRs to move along these changes faster in bulk.

- Sets default port for `nextcloud.containerPort` to be `80` in values.yaml.
- Changes the service `targetPort` for the nextcloud service to be the `nextcloud.containerPort`.
- Changes all `http` ports in the deployment template to use `nextcloud.containerPort` instead (includes probes)

## Benefits
allows users to set a custom container port like `9000` and have it be referenced in the service.

## Possible drawbacks
unsure, open to suggestion

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #384 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
