### PR TITLE
Add `--target-branch` to linting and install helm chart GHA testing steps

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run chart-testing (lint)
         id: lint
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --config ct.yaml
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
@@ -52,4 +52,4 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
# Pull Request

## Description of the change

Updates `ct` commands in both the linting and installing steps to now use the param for target branch:
 `--target-branch ${{ github.event.repository.default_branch }}`

## Benefits

now we match the example in the readme here:
https://github.com/helm/chart-testing-action

Without it, it was causing these issues:
https://github.com/nextcloud/helm/actions/runs/4787913488/jobs/8513797467

```log
Run ct install --config ct.yaml
  ct install --config ct.yaml
  shell: /usr/bin/bash -e {0}
  env:
    CT_CONFIG_DIR: /opt/hostedtoolcache/ct/v3.8.0/x86_64/etc
    VIRTUAL_ENV: /opt/hostedtoolcache/ct/v3.8.0/x86_64/venv
Installing charts...
Error: failed installing charts: failed identifying charts to process: failed running process: exit status 128
------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
failed installing charts: failed identifying charts to process: failed running process: exit status 128
Error: Process completed with exit code 1.
```

## Possible drawbacks

can't tell if we need the ct.yml anymore 🤷 

## Applicable issues
No issues yet 😅 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
