### PR TITLE
fix(metrics-deployment): use service name and port

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.10
+version: 3.5.11
 appVersion: 26.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -51,7 +51,7 @@ spec:
               key: {{ .Values.nextcloud.existingSecret.passwordKey | default "nextcloud-password" }}
         {{- end }}
         - name: NEXTCLOUD_SERVER
-          value: http{{ if .Values.metrics.https }}s{{ end }}://{{ .Values.nextcloud.host }}
+          value: http{{ if .Values.metrics.https }}s{{ end }}://{{ template "nextcloud.fullname" . }}:{{ .Values.service.port }}
         - name: NEXTCLOUD_TIMEOUT
           value: {{ .Values.metrics.timeout }}
         - name: NEXTCLOUD_TLS_SKIP_VERIFY

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -50,6 +50,7 @@ spec:
               name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
               key: {{ .Values.nextcloud.existingSecret.passwordKey | default "nextcloud-password" }}
         {{- end }}
+        # NEXTCLOUD_SERVER is used by metrics-exporter to reach the Nextcloud (K8s-)Service to grab the serverinfo api endpoint
         - name: NEXTCLOUD_SERVER
           value: http{{ if .Values.metrics.https }}s{{ end }}://{{ template "nextcloud.fullname" . }}:{{ .Values.service.port }}
         - name: NEXTCLOUD_TIMEOUT


### PR DESCRIPTION
# Pull Request

## Description of the change

As stated out by @millaguie, the NEXTCLOUD_SERVER variable of [metrics-deployment](https://github.com/nextcloud/helm/blob/b35eaa38a721542d7ce73d07e123aa0574244c26/charts/nextcloud/templates/metrics-deployment.yaml#L53) should point to the Nextcloud Service name. But that gets its name from the template function `nextcloud.fullname` and not `.Values.nextcloud.host`. 
Also the port was not contained, that both is changed now.

## Benefits

`metrics-exporter`is now able to reach the Nextcloud Service correctly

## Applicable issues

- fixes [#279](https://github.com/nextcloud/helm/issues/279)


- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
