### PR TITLE
add security context config to mariadb-isalive and postgresql-isready…

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.0.2
+version: 5.1.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -293,6 +293,10 @@ spec:
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
+          {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
+          securityContext:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: MYSQL_USER
               valueFrom:
@@ -311,6 +315,10 @@ spec:
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+          {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
+          securityContext:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               valueFrom:

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -293,7 +293,7 @@ spec:
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
-          {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
+          {{- with .Values.nextcloud.mariaDbInitContainer.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -315,7 +315,7 @@ spec:
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-          {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
+          {{- with .Values.nextcloud.postgreSqlInitContainer.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -295,7 +295,7 @@ spec:
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
           {{- with .Values.nextcloud.mariadbInitContainerSecurityContext }}
           securityContext:
-              {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: MYSQL_USER
@@ -317,7 +317,7 @@ spec:
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
           {{- with .Values.nextcloud.postgresqlInitContainerSecurityContext }}
           securityContext:
-              {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: POSTGRES_USER

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -213,18 +213,23 @@ nextcloud:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
 
-  # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
-  mariadbInitContainerSecurityContext: {}
-
-  # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
-  postgresqlInitContainerSecurityContext: {}
-
   # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
   podSecurityContext: {}
   #   runAsUser: 33
   #   runAsGroup: 33
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
+
+  # Settings for the MariaDB init container
+  mariaDbInitContainer:
+    # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+    securityContext: {}
+
+  # Settings for the PostgreSQL init container
+  postgreSqlInitContainer:
+    # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+    securityContext: {}
+
 
 nginx:
   ## You need to set an fpm version of the image for nextcloud if you want to use nginx!

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -213,6 +213,12 @@ nextcloud:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: false
 
+  # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+  mariadbInitContainerSecurityContext: {}
+
+  # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
+  postgresqlInitContainerSecurityContext: {}
+
   # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
   podSecurityContext: {}
   #   runAsUser: 33


### PR DESCRIPTION
# Pull Request

## Description of the change

The SecurityContext configuration was not applied to the InitContainers before. This PR fixes this.

## Benefits

The SecurityContext is applied to all containers in the main Deployment and can therefore be started in Openshift with the correct configuration.

## Possible drawbacks

SecurityContext is the same for all containers of the main Deployment and can not be configured individually. Although, this is not a issue introduced here and should not be a problem.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
