### PR TITLE
ServiceMonitor: Specify monitored namespace

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.16
+version: 3.5.17
 appVersion: 27.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/metrics-servicemonitor.yaml
+++ b/charts/nextcloud/templates/metrics-servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
       app.kubernetes.io/name: {{ include "nextcloud.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
   endpoints:
     - port: metrics
       path: "/"


### PR DESCRIPTION
# Pull Request

## Description of the change

This Pull Request should utilize the Helm Release Namespace as a target for the `ServiceMonitor` this Helmchart is optionally deploying.

## Benefits

The metrics actually show up in Prometheus.

## Possible drawbacks

I don't see any.

## Applicable issues

- fixes #312 

## Additional information

None

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] ~~(optional) Variables are documented in the README.md~~
