### PR TITLE
add auto generated release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,3 +47,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
# Pull Request

## Description of the change

So I took a peek at the way [argorproj/argo-helm](https://github.com/argoproj/argo-helm/blob/047ba6b24df9977ec773ca5cf0f00a70565e5c06/.github/workflows/publish.yml#L57-L60) does their releases and it looks like we can just pass in a config file like they've done [here](https://github.com/argoproj/argo-helm/blob/main/.github/configs/cr.yaml).

## Benefits
This _should_ auto-generate release notes going forward!

## Possible drawbacks

not sure

## Applicable issues

- fixes #250

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
