### PR TITLE
Add concurrency, remove softprops/turnstyle action for Release Charts workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 
 name: Release Charts
+# only run one instance of this workflow at a time
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency: chart_releaser
 
 on:
   push:
@@ -17,13 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Turnstyle
-        uses: softprops/turnstyle@v1
-        with:
-          continue-after-seconds: 180
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
 
       - name: Fetch history
         run: git fetch --prune --unshallow


### PR DESCRIPTION
## Description of the change

Removes the [softprops/turnstyle](https://github.com/softprops/turnstyle) GitHub Action, and replaces it with the now built in [`concurrency`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) feature for GitHub Workflows.

## Benefits

- Uses the built in feature of GitHub Workflows, which will always wait based on the name of the concurrency group you set, so even if two PRs were merged at the same time, one action would still need to wait for the other.

- One less dependency to keep track of, and in particular turnstyle is using a [deprecated version of nodejs](https://github.com/softprops/turnstyle/blob/ca99add00ff0c9cbc697d22631d2992f377e5bd5/action.yml#L8) that will soon be phased out by GitHub.

- This removes the "The `set-output` command is deprecated" warnings as show in [actions/runs/5528834833](https://github.com/nextcloud/helm/actions/runs/5528834833):
<img width="1139" alt="Screenshot 2023-07-12 at 12 14 44" src="https://github.com/nextcloud/helm/assets/2389292/0dedf525-e0c1-481e-b5bc-e6f815df9e52">
<img width="1496" alt="Screenshot 2023-07-12 at 12 26 43" src="https://github.com/nextcloud/helm/assets/2389292/09ff5ace-420e-42c1-945f-3ed71cad0e21">

## Possible drawbacks

None that jump out at me.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md