### PR TITLE
README updates: Add occ command examples; Clean up readme tables; Clean up branding; change supported k8s version

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -454,7 +454,7 @@ Some admin actions require you to put your Nextcloud instance into [maintanence 
 
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
-kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ maintenance:mode --on"
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ maintenance:mode --on"
 ```
 
 ### Downloading models for recognize
@@ -462,5 +462,5 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ maintenance:
 
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
-kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ recognize:download-models"
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ recognize:download-models"
 ```

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -444,10 +444,10 @@ Sometimes you need to run an [occ](https://docs.nextcloud.com/server/latest/admi
 
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
-kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ myocccomand"
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ myocccomand"
 ```
 
-Here's some examples below.
+Here are some examples below.
 
 ### Putting Nextcloud into maintanence mode
 Some admin actions require you to put your Nextcloud instance into [maintanence mode](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html#maintenance-mode) (e.g. backups). You can do so like this:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -1,6 +1,6 @@
-# nextcloud
+# Nextcloud Helm Chart
 
-[nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
+[Nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
 
 ## TL;DR;
 
@@ -8,6 +8,26 @@
 helm repo add nextcloud https://nextcloud.github.io/helm/
 helm install my-release nextcloud/nextcloud
 ```
+
+## Quick Links
+
+* [Introduction](#introduction)
+* [Prerequisites](#prerequisites)
+* [Installing the Chart](#installing-the-chart)
+* [Uninstalling the Chart](#uninstalling-the-chart)
+* [Configuration](#configuration)
+    * [Database Configurations](#database-configurations)
+    * [Persistence Configurations](#persistence-configurations)
+    * [Metrics Configurations](#metrics-configurations)
+* [Cronjob](#cronjob)
+* [Multiple config.php file](#multiple-configphp-file)
+* [Using nginx](#using-nginx)
+* [Preserving Source IP](#preserving-source-ip)
+* [Hugepages](#hugepages)
+* [HPA (Clustering)](#hpa-clustering)
+* [Running `occ` commands](#running-occ-commands)
+    * [Putting Nextcloud into maintanence mode](#putting-nextcloud-into-maintanence-mode)
+    * [Downloading models for recognize](#downloading-models-for-recognize)
 
 ## Introduction
 
@@ -17,12 +37,17 @@ You will also need a database compatible with Nextcloud. For more info, please s
 
 If you want to persist data accross installs and upgrades, you'll need to configure persistence. For more info, please see the [Persistence Configuration](#persistence-configurations) section below.
 
-We also package a Redis helm chart as an _optional_ caching system from Bitnami:
-- [Bitnami Redis Chart](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+We also package the following helm charts from Bitnami for you to _optionally_ use:
+
+| Chart                                                                        | Descrption                      |
+|------------------------------------------------------------------------------|---------------------------------|
+| [Redis](https://github.com/bitnami/charts/tree/main/bitnami/redis)           | For enabling caching            |
+| [PostgreSQL](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) | For use as an external database |
+| [MariaDB](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)       | For use as an external database |
 
 ## Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.24+
 - Persistent Volume provisioner support in the underlying infrastructure
 - Helm >=3.7.0 ([for subchart scope exposing](nextcloud/helm#152))
 
@@ -53,117 +78,117 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                            | Description                                                                            | Default                                      |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
-| `image.repository`                                                   | nextcloud Image name                                                                   | `nextcloud`                                  |
-| `image.flavor`                                                       | nextcloud Image type (Options: apache, fpm)                                            | `apache`                                     |
-| `image.tag`                                                          | nextcloud Image tag                                                                    | `{VERSION}`                                  |
-| `image.pullPolicy`                                                   | Image pull policy                                                                      | `IfNotPresent`                               |
-| `image.pullSecrets`                                                  | Specify image pull secrets                                                             | `nil`                                        |
-| `replicaCount`                                                       | Number of nextcloud pods to deploy                                                     | `1`                                          |
-| `ingress.className`                                                  | Name of the ingress class to use                                                       | `nil`                                        |
-| `ingress.enabled`                                                    | Enable use of ingress controllers                                                      | `false`                                      |
-| `ingress.servicePort`                                                | Ingress' backend servicePort                                                           | `http`                                       |
-| `ingress.annotations`                                                | An array of service annotations                                                        | `nil`                                        |
-| `ingress.labels`                                                     | An array of service labels                                                             | `nil`                                        |
-| `ingress.path`                                                       | The `Path` to use in Ingress' `paths`                                                  | `/`                                          |
-| `ingress.pathType`                                                   | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                                     |
-| `ingress.tls`                                                        | Ingress TLS configuration                                                              | `[]`                                         |
-| `nextcloud.host`                                                     | nextcloud host to create application URLs                                              | `nextcloud.kube.home`                        |
-| `nextcloud.username`                                                 | User of the application                                                                | `admin`                                      |
-| `nextcloud.password`                                                 | Application password                                                                   | `changeme`                                   |
-| `nextcloud.existingSecret.enabled`                                   | Whether to use an existing secret or not                                               | `false`                                      |
-| `nextcloud.existingSecret.secretName`                                | Name of the existing secret                                                            | `nil`                                        |
-| `nextcloud.existingSecret.usernameKey`                               | Name of the key that contains the username                                             | `nil`                                        |
-| `nextcloud.existingSecret.passwordKey`                               | Name of the key that contains the password                                             | `nil`                                        |
-| `nextcloud.existingSecret.smtpUsernameKey`                           | Name of the key that contains the SMTP username                                        | `nil`                                        |
-| `nextcloud.existingSecret.smtpPasswordKey`                           | Name of the key that contains the SMTP password                                        | `nil`                                        |
-| `nextcloud.update`                                                   | Trigger update if custom command is used                                               | `0`                                          |
-| `nextcloud.containerPort`                                            | Customize container port when not running as root                                      | `80`                                         |
-| `nextcloud.datadir`                                                  | nextcloud data dir location                                                            | `/var/www/html/data`                         |
-| `nextcloud.mail.enabled`                                             | Whether to enable/disable email settings                                               | `false`                                      |
-| `nextcloud.mail.fromAddress`                                         | nextcloud mail send from field                                                         | `nil`                                        |
-| `nextcloud.mail.domain`                                              | nextcloud mail domain                                                                  | `nil`                                        |
-| `nextcloud.mail.smtp.host`                                           | SMTP hostname                                                                          | `nil`                                        |
-| `nextcloud.mail.smtp.secure`                                         | SMTP connection `ssl` or empty                                                         | `''`                                         |
-| `nextcloud.mail.smtp.port`                                           | Optional SMTP port                                                                     | `nil`                                        |
-| `nextcloud.mail.smtp.authtype`                                       | SMTP authentication method                                                             | `LOGIN`                                      |
-| `nextcloud.mail.smtp.name`                                           | SMTP username                                                                          | `''`                                         |
-| `nextcloud.mail.smtp.password`                                       | SMTP password                                                                          | `''`                                         |
-| `nextcloud.configs`                                                  | Config files created in `/var/www/html/config`                                         | `{}`                                         |
-| `nextcloud.persistence.subPath`                                      | Set the subPath for nextcloud to use in volume                                         | `nil`                                        |
-| `nextcloud.phpConfigs`                                               | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                                         |
-| `nextcloud.defaultConfigs.\.htaccess`                                | Default .htaccess to protect `/var/www/html/config`                                    | `true`                                       |
-| `nextcloud.defaultConfigs.redis\.config\.php`                        | Default Redis configuration                                                            | `true`                                       |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`           | Default Apache configuration for rewrite urls                                          | `true`                                       |
-| `nextcloud.defaultConfigs.apcu\.config\.php`                         | Default configuration to define APCu as local cache                                    | `true`                                       |
-| `nextcloud.defaultConfigs.apps\.config\.php`                         | Default configuration for apps                                                         | `true`                                       |
-| `nextcloud.defaultConfigs.autoconfig\.php`                           | Default auto-configuration for databases                                               | `true`                                       |
-| `nextcloud.defaultConfigs.smtp\.config\.php`                         | Default configuration for smtp                                                         | `true`                                       |
-| `nextcloud.strategy`                                                 | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`                             |
-| `nextcloud.extraEnv`                                                 | specify additional environment variables                                               | `{}`                                         |
-| `nextcloud.extraSidecarContainers`                                   | specify additional sidecar containers                                                  | `[]`                                         |
-| `nextcloud.extraInitContainers`                                      | specify additional init containers                                                     | `[]`                                         |
-| `nextcloud.extraVolumes`                                             | specify additional volumes for the NextCloud pod                                       | `{}`                                         |
-| `nextcloud.extraVolumeMounts`                                        | specify additional volume mounts for the NextCloud pod                                 | `{}`                                         |
-| `nextcloud.securityContext`                                          | Optional security context for the NextCloud container                                  | `nil`                                        |
-| `nextcloud.podSecurityContext`                                       | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                                        |
-| `nginx.enabled`                                                      | Enable nginx (requires you use php-fpm image)                                          | `false`                                      |
-| `nginx.image.repository`                                             | nginx Image name                                                                       | `nginx`                                      |
-| `nginx.image.tag`                                                    | nginx Image tag                                                                        | `alpine`                                     |
-| `nginx.image.pullPolicy`                                             | nginx Image pull policy                                                                | `IfNotPresent`                               |
-| `nginx.config.default`                                               | Whether to use nextcloud's recommended nginx config                                    | `true`                                       |
-| `nginx.config.custom`                                                | Specify a custom config for nginx                                                      | `{}`                                         |
-| `nginx.resources`                                                    | nginx resources                                                                        | `{}`                                         |
-| `nginx.securityContext`                                              | Optional security context for the nginx container                                      | `nil`                                        |
-| `lifecycle.postStartCommand`                                         | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
-| `lifecycle.preStopCommand`                                           | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
-| `redis.enabled`                                                      | Whether to install/use redis for locking                                               | `false`                                      |
-| `redis.auth.enabled`                                                 | Whether to enable password authentication with redis                                   | `true`                                       |
-| `redis.auth.password`                                                | The password redis uses                                                                | `''`                                         |
-| `redis.auth.existingSecret`                                          | The name of an existing secret with Redis® credentials                                 | `''`                                         |
-| `redis.auth.existingSecretPasswordKey`                               | Password key to be retrieved from existing secret                                      | `''`                                         |
-| `cronjob.enabled`                                                    | Whether to enable/disable cronjob                                                      | `false`                                      |
-| `cronjob.lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand                                     | `nil`                                        |
-| `cronjob.lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand                                       | `nil`                                        |
-| `cronjob.resources`                                                  | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                                         |
-| `cronjob.securityContext`                                            | Optional security context for cronjob                                                  | `nil`                                        |
-| `service.type`                                                       | Kubernetes Service type                                                                | `ClusterIP`                                  |
-| `service.loadBalancerIP`                                             | LoadBalancerIp for service type LoadBalancer                                           | `nil`                                        |
-| `service.nodePort`                                                   | NodePort for service type NodePort                                                     | `nil`                                        |
-| `phpClientHttpsFix.enabled`                                          | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                                      |
-| `phpClientHttpsFix.protocol`                                         | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                                      |
-| `resources`                                                          | CPU/Memory resource requests/limits                                                    | `{}`                                         |
-| `rbac.enabled`                                                       | Enable Role and rolebinding for priveledged PSP                                        | `false`                                      |
-| `rbac.serviceaccount.create`                                         | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                                       |
-| `rbac.serviceaccount.name`                                           | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount`                   |
-| `rbac.serviceaccount.annotations`                                    | Serviceaccount annotations                                                             | `{}`                                         |
-| `livenessProbe.enabled`                                              | Turn on and off liveness probe                                                         | `true`                                       |
-| `livenessProbe.initialDelaySeconds`                                  | Delay before liveness probe is initiated                                               | `10`                                         |
-| `livenessProbe.periodSeconds`                                        | How often to perform the probe                                                         | `10`                                         |
-| `livenessProbe.timeoutSeconds`                                       | When the probe times out                                                               | `5`                                          |
-| `livenessProbe.failureThreshold`                                     | Minimum consecutive failures for the probe                                             | `3`                                          |
-| `livenessProbe.successThreshold`                                     | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `readinessProbe.enabled`                                             | Turn on and off readiness probe                                                        | `true`                                       |
-| `readinessProbe.initialDelaySeconds`                                 | Delay before readiness probe is initiated                                              | `10`                                         |
-| `readinessProbe.periodSeconds`                                       | How often to perform the probe                                                         | `10`                                         |
-| `readinessProbe.timeoutSeconds`                                      | When the probe times out                                                               | `5`                                          |
-| `readinessProbe.failureThreshold`                                    | Minimum consecutive failures for the probe                                             | `3`                                          |
-| `readinessProbe.successThreshold`                                    | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `startupProbe.enabled`                                               | Turn on and off startup probe                                                          | `false`                                      |
-| `startupProbe.initialDelaySeconds`                                   | Delay before readiness probe is initiated                                              | `30`                                         |
-| `startupProbe.periodSeconds`                                         | How often to perform the probe                                                         | `10`                                         |
-| `startupProbe.timeoutSeconds`                                        | When the probe times out                                                               | `5`                                          |
-| `startupProbe.failureThreshold`                                      | Minimum consecutive failures for the probe                                             | `30`                                         |
-| `startupProbe.successThreshold`                                      | Minimum consecutive successes for the probe                                            | `1`                                          |
-| `hpa.enabled`                                                        | Boolean to create a HorizontalPodAutoscaler                                            | `false`                                      |
-| `hpa.cputhreshold`                                                   | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                                         |
-| `hpa.minPods`                                                        | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                                          |
-| `hpa.maxPods`                                                        | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                                         |
-| `deploymentLabels`                                                   | Labels to be added at 'deployment' level                                               | not set                                      |
-| `deploymentAnnotations`                                              | Annotations to be added at 'deployment' level                                          | not set                                      |
-| `podLabels`                                                          | Labels to be added at 'pod' level                                                      | not set                                      |
-| `podAnnotations`                                                     | Annotations to be added at 'pod' level                                                 | not set                                      |
+| Parameter                                                  | Description                                                                            | Default                    |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------|
+| `image.repository`                                         | nextcloud Image name                                                                   | `nextcloud`                |
+| `image.flavor`                                             | nextcloud Image type (Options: apache, fpm)                                            | `apache`                   |
+| `image.tag`                                                | nextcloud Image tag                                                                    | `appVersion`               |
+| `image.pullPolicy`                                         | Image pull policy                                                                      | `IfNotPresent`             |
+| `image.pullSecrets`                                        | Specify image pull secrets                                                             | `nil`                      |
+| `replicaCount`                                             | Number of nextcloud pods to deploy                                                     | `1`                        |
+| `ingress.className`                                        | Name of the ingress class to use                                                       | `nil`                      |
+| `ingress.enabled`                                          | Enable use of ingress controllers                                                      | `false`                    |
+| `ingress.servicePort`                                      | Ingress' backend servicePort                                                           | `http`                     |
+| `ingress.annotations`                                      | An array of service annotations                                                        | `nil`                      |
+| `ingress.labels`                                           | An array of service labels                                                             | `nil`                      |
+| `ingress.path`                                             | The `Path` to use in Ingress' `paths`                                                  | `/`                        |
+| `ingress.pathType`                                         | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                   |
+| `ingress.tls`                                              | Ingress TLS configuration                                                              | `[]`                       |
+| `nextcloud.host`                                           | nextcloud host to create application URLs                                              | `nextcloud.kube.home`      |
+| `nextcloud.username`                                       | User of the application                                                                | `admin`                    |
+| `nextcloud.password`                                       | Application password                                                                   | `changeme`                 |
+| `nextcloud.existingSecret.enabled`                         | Whether to use an existing secret or not                                               | `false`                    |
+| `nextcloud.existingSecret.secretName`                      | Name of the existing secret                                                            | `nil`                      |
+| `nextcloud.existingSecret.usernameKey`                     | Name of the key that contains the username                                             | `nil`                      |
+| `nextcloud.existingSecret.passwordKey`                     | Name of the key that contains the password                                             | `nil`                      |
+| `nextcloud.existingSecret.smtpUsernameKey`                 | Name of the key that contains the SMTP username                                        | `nil`                      |
+| `nextcloud.existingSecret.smtpPasswordKey`                 | Name of the key that contains the SMTP password                                        | `nil`                      |
+| `nextcloud.update`                                         | Trigger update if custom command is used                                               | `0`                        |
+| `nextcloud.containerPort`                                  | Customize container port when not running as root                                      | `80`                       |
+| `nextcloud.datadir`                                        | nextcloud data dir location                                                            | `/var/www/html/data`       |
+| `nextcloud.mail.enabled`                                   | Whether to enable/disable email settings                                               | `false`                    |
+| `nextcloud.mail.fromAddress`                               | nextcloud mail send from field                                                         | `nil`                      |
+| `nextcloud.mail.domain`                                    | nextcloud mail domain                                                                  | `nil`                      |
+| `nextcloud.mail.smtp.host`                                 | SMTP hostname                                                                          | `nil`                      |
+| `nextcloud.mail.smtp.secure`                               | SMTP connection `ssl` or empty                                                         | `''`                       |
+| `nextcloud.mail.smtp.port`                                 | Optional SMTP port                                                                     | `nil`                      |
+| `nextcloud.mail.smtp.authtype`                             | SMTP authentication method                                                             | `LOGIN`                    |
+| `nextcloud.mail.smtp.name`                                 | SMTP username                                                                          | `''`                       |
+| `nextcloud.mail.smtp.password`                             | SMTP password                                                                          | `''`                       |
+| `nextcloud.configs`                                        | Config files created in `/var/www/html/config`                                         | `{}`                       |
+| `nextcloud.persistence.subPath`                            | Set the subPath for nextcloud to use in volume                                         | `nil`                      |
+| `nextcloud.phpConfigs`                                     | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                       |
+| `nextcloud.defaultConfigs.\.htaccess`                      | Default .htaccess to protect `/var/www/html/config`                                    | `true`                     |
+| `nextcloud.defaultConfigs.redis\.config\.php`              | Default Redis configuration                                                            | `true`                     |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls                                          | `true`                     |
+| `nextcloud.defaultConfigs.apcu\.config\.php`               | Default configuration to define APCu as local cache                                    | `true`                     |
+| `nextcloud.defaultConfigs.apps\.config\.php`               | Default configuration for apps                                                         | `true`                     |
+| `nextcloud.defaultConfigs.autoconfig\.php`                 | Default auto-configuration for databases                                               | `true`                     |
+| `nextcloud.defaultConfigs.smtp\.config\.php`               | Default configuration for smtp                                                         | `true`                     |
+| `nextcloud.strategy`                                       | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`           |
+| `nextcloud.extraEnv`                                       | specify additional environment variables                                               | `{}`                       |
+| `nextcloud.extraSidecarContainers`                         | specify additional sidecar containers                                                  | `[]`                       |
+| `nextcloud.extraInitContainers`                            | specify additional init containers                                                     | `[]`                       |
+| `nextcloud.extraVolumes`                                   | specify additional volumes for the NextCloud pod                                       | `{}`                       |
+| `nextcloud.extraVolumeMounts`                              | specify additional volume mounts for the NextCloud pod                                 | `{}`                       |
+| `nextcloud.securityContext`                                | Optional security context for the NextCloud container                                  | `nil`                      |
+| `nextcloud.podSecurityContext`                             | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                      |
+| `nginx.enabled`                                            | Enable nginx (requires you use php-fpm image)                                          | `false`                    |
+| `nginx.image.repository`                                   | nginx Image name                                                                       | `nginx`                    |
+| `nginx.image.tag`                                          | nginx Image tag                                                                        | `alpine`                   |
+| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                | `IfNotPresent`             |
+| `nginx.config.default`                                     | Whether to use nextcloud's recommended nginx config                                    | `true`                     |
+| `nginx.config.custom`                                      | Specify a custom config for nginx                                                      | `{}`                       |
+| `nginx.resources`                                          | nginx resources                                                                        | `{}`                       |
+| `nginx.securityContext`                                    | Optional security context for the nginx container                                      | `nil`                      |
+| `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                     | `nil`                      |
+| `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                       | `nil`                      |
+| `redis.enabled`                                            | Whether to install/use redis for locking                                               | `false`                    |
+| `redis.auth.enabled`                                       | Whether to enable password authentication with redis                                   | `true`                     |
+| `redis.auth.password`                                      | The password redis uses                                                                | `''`                       |
+| `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                 | `''`                       |
+| `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                      | `''`                       |
+| `cronjob.enabled`                                          | Whether to enable/disable cronjob                                                      | `false`                    |
+| `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand                                     | `nil`                      |
+| `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand                                       | `nil`                      |
+| `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                       |
+| `cronjob.securityContext`                                  | Optional security context for cronjob                                                  | `nil`                      |
+| `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                           | `nil`                      |
+| `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
+| `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
+| `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |
+| `resources`                                                | CPU/Memory resource requests/limits                                                    | `{}`                       |
+| `rbac.enabled`                                             | Enable Role and rolebinding for priveledged PSP                                        | `false`                    |
+| `rbac.serviceaccount.create`                               | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                     |
+| `rbac.serviceaccount.name`                                 | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount` |
+| `rbac.serviceaccount.annotations`                          | Serviceaccount annotations                                                             | `{}`                       |
+| `livenessProbe.enabled`                                    | Turn on and off liveness probe                                                         | `true`                     |
+| `livenessProbe.initialDelaySeconds`                        | Delay before liveness probe is initiated                                               | `10`                       |
+| `livenessProbe.periodSeconds`                              | How often to perform the probe                                                         | `10`                       |
+| `livenessProbe.timeoutSeconds`                             | When the probe times out                                                               | `5`                        |
+| `livenessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                             | `3`                        |
+| `livenessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                            | `1`                        |
+| `readinessProbe.enabled`                                   | Turn on and off readiness probe                                                        | `true`                     |
+| `readinessProbe.initialDelaySeconds`                       | Delay before readiness probe is initiated                                              | `10`                       |
+| `readinessProbe.periodSeconds`                             | How often to perform the probe                                                         | `10`                       |
+| `readinessProbe.timeoutSeconds`                            | When the probe times out                                                               | `5`                        |
+| `readinessProbe.failureThreshold`                          | Minimum consecutive failures for the probe                                             | `3`                        |
+| `readinessProbe.successThreshold`                          | Minimum consecutive successes for the probe                                            | `1`                        |
+| `startupProbe.enabled`                                     | Turn on and off startup probe                                                          | `false`                    |
+| `startupProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                                              | `30`                       |
+| `startupProbe.periodSeconds`                               | How often to perform the probe                                                         | `10`                       |
+| `startupProbe.timeoutSeconds`                              | When the probe times out                                                               | `5`                        |
+| `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                             | `30`                       |
+| `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                            | `1`                        |
+| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                            | `false`                    |
+| `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                       |
+| `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                        |
+| `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                       |
+| `deploymentLabels`                                         | Labels to be added at 'deployment' level                                               | not set                    |
+| `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                          | not set                    |
+| `podLabels`                                                | Labels to be added at 'pod' level                                                      | not set                    |
+| `podAnnotations`                                           | Annotations to be added at 'pod' level                                                 | not set                    |
 
 
 ### Database Configurations
@@ -411,4 +436,31 @@ Minimum cluster compatible persistence settings:
 persistence:
   enabled: true
   accessMode: ReadWriteMany
+```
+
+
+## Running `occ` commands
+Sometimes you need to run an [occ](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html) command on the Nextcloud container directly. You can do that by running commands as the user `www-data` via the `kubectl exec` command.
+
+```bash
+# $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ myocccomand"
+```
+
+Here's some examples below.
+
+### Putting Nextcloud into maintanence mode
+Some admin actions require you to put your Nextcloud instance into [maintanence mode](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html#maintenance-mode) (e.g. backups). You can do so like this:
+
+```bash
+# $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ maintenance:mode --on"
+```
+
+### Downloading models for recognize
+[Recognize](https://github.com/nextcloud/recognize) requies you download models before using it, so you would do so like this:
+
+```bash
+# $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
+kubectl exec $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ recognize:download-models"
 ```

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -450,7 +450,7 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ myocccomand"
 Here are some examples below.
 
 ### Putting Nextcloud into maintanence mode
-Some admin actions require you to put your Nextcloud instance into [maintanence mode](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html#maintenance-mode) (e.g. backups). You can do so like this:
+Some admin actions require you to put your Nextcloud instance into [maintanence mode](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html#maintenance-mode) (e.g. backups):
 
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
@@ -458,7 +458,7 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ maintenance:mo
 ```
 
 ### Downloading models for recognize
-[Recognize](https://github.com/nextcloud/recognize) requies you download models before using it, so you would do so like this:
+[Recognize](https://github.com/nextcloud/recognize) requires you to download models before using it:
 
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)


### PR DESCRIPTION
# Pull Request

## Description of the change
- Adds occ command examples - a frequently asked question
- Clean up readme tables - resized to fit data (thanks [dhruvasagar/vim-table-mode](https://github.com/dhruvasagar/vim-table-mode))
- Clean up branding of "nextcloud" to "Nextcloud"
- change supported k8s version - ticks up to the [oldest support k8s release](https://kubernetes.io/releases/)
- adds a table of contents because we have a lot of sections now :D (thanks [mzlogin/vim-markdown-toc](https://github.com/mzlogin/vim-markdown-toc))

## Benefits

Just helps make the readme a bit more presentable and also adds another tidbit of info for those looking to run occ commands.

## Possible drawbacks

🤷 I'm open to feedback

## Applicable issues
for the occ part:
https://github.com/nextcloud/helm/issues/45

it's also come up in two discussions:
https://github.com/nextcloud/helm/discussions/301
https://github.com/nextcloud/helm/discussions/352

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
