### PR TITLE
Update nextcloud app version to `27.0.1`

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.19
-appVersion: 27.0.0
+version: 3.5.20
+appVersion: 27.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -28,6 +28,7 @@ helm install my-release nextcloud/nextcloud
 * [Running `occ` commands](#running-occ-commands)
     * [Putting Nextcloud into maintanence mode](#putting-nextcloud-into-maintanence-mode)
     * [Downloading models for recognize](#downloading-models-for-recognize)
+* [Upgrades](#upgrades)
 
 ## Introduction
 
@@ -465,4 +466,19 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ maintenance:mo
 ```bash
 # $NEXTCLOUD_POD should be the name of *your* nextcloud pod :)
 kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ recognize:download-models"
+```
+
+# Backups
+Check out the [official Nextcloud backup docs](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). For your files, if you're using persistent volumes, and you'd like to back up to s3 backed storage (such as minio), consider using [k8up](https://github.com/k8up-io/k8up) or [velero](https://github.com/vmware-tanzu/velero). 
+
+# Upgrades
+Since this chart utilizes the [nextcloud/docker](https://github.com/nextcloud/docker) image, provided you are using persistent volumes, [upgrades of your Nextcloud server are handled automatically](https://github.com/nextcloud/docker#update-to-a-newer-version) from one version to the next, however, you can only upgrade one major version at a time. For example, if you want to upgrade from version `25` to `27`, you will have to upgrade from version `25` to `26`, then from `26` to `27`. Since our docker tag is set via the [`appVersion` in `Chart.yaml`](https://github.com/nextcloud/helm/blob/main/charts/nextcloud/Chart.yaml#L4), you'll need to make sure you gradually upgrade the helm chart if you have missed serveral app versions. 
+
+⚠️ *Before Upgrading Nextcloud or the attached database, always make sure you take [backups](#backups)!*
+
+After an upgrade, you may have missing indices. To fix this, you can run:
+
+```bash
+# where NEXTCLOUD_POD is *your* nextcloud pod
+kubectl exec -it $NEXTCLOUD_POD -- su -s /bin/bash www-data -c "php occ db:add-missing-indices"
 ```

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -28,6 +28,7 @@ helm install my-release nextcloud/nextcloud
 * [Running `occ` commands](#running-occ-commands)
     * [Putting Nextcloud into maintanence mode](#putting-nextcloud-into-maintanence-mode)
     * [Downloading models for recognize](#downloading-models-for-recognize)
+* [Backups](#backups)
 * [Upgrades](#upgrades)
 
 ## Introduction


### PR DESCRIPTION
# Pull Request

## Description of the change
Updates the default image tag to `27.0.1`

## Benefits

latest stable version as of yesterday

## Possible drawbacks / Considerations

Still no upgrade guide. This'll be the first time I'm upgrading a production instance, so happy to write up a guide on it. Is it just setting `nextcloud.update` to `1`? 🤔 Does that enable the auto-updater? Right now I have it set to the default, `0` and when I go to https://cloud.mydomain.com/updater/ it gives a 404, so maybe that's why? If I set it to `1` before upgrading the helm chart version, and just run a `helm upgrade` with the new values.yaml, will that break anything? I'll obviously take backups before this, but it would be nice to have a section of the README for this as upgrades are a common question we get in the issues.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
