### PR TITLE
Upgrade Redis, Postgresql, and Maridb to latest OCI Bitnami helm chart versions

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.6.26
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 12.6.9
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.0.14
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 12.2.8
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.12.3
-digest: sha256:26d3436ece41f0fbe00d0184c1cda7f5cccb7d49642982cfff49f113c11c0f34
-generated: "2022-10-30T11:48:19.745391397+01:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 17.13.2
+digest: sha256:e292db0f38d48fdde0b9feff58c406eef920c7e3b592e7f0ec1907e7599a7a2b
+generated: "2023-07-24T16:19:14.475458+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.19
+version: 4.0.0
 appVersion: 27.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
     email: jeff@billimek.com
 dependencies:
   - name: postgresql
-    version: 11.6.*
-    repository: https://charts.bitnami.com/bitnami
+    version: 12.6.*
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mariadb
-    version: 11.0.*
-    repository: https://charts.bitnami.com/bitnami
+    version: 12.2.*
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: mariadb.enabled
   - name: redis
-    version: 16.12.*
-    repository: https://charts.bitnami.com/bitnami
+    version: 17.13.*
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled


### PR DESCRIPTION
# Pull Request

## Description of the change

- Upgrades all bitnami subcharts to the latest major versions at time of commit:
  - Postgresql appVersion will be bumped from [`14.4.x`](https://github.com/bitnami/charts/blob/b722e860bbb104d308457b49702bc22ff04b6cc1/bitnami/postgresql/Chart.yaml) to [`15.3.0`](https://github.com/bitnami/charts/blob/f985538a832c556241bdc9d90cc7e6eb2c3686df/bitnami/postgresql/Chart.yaml#L8)
  - MariaDB appVersion will be bumped from [`10.6.x`](https://github.com/bitnami/charts/blob/fb42c688539128bf5f295595bcd053072e28b1b6/bitnami/mariadb/Chart.yaml#L4) to [`10.11.4`](https://github.com/bitnami/charts/blob/f985538a832c556241bdc9d90cc7e6eb2c3686df/bitnami/mariadb/Chart.yaml#L8C13-L8C20)
  - Redis appVersion will be bumped from [`6.2.x`](https://github.com/bitnami/charts/blob/fd2e02ba9c51b8043636055fbb129861461ab9f0/bitnami/redis/Chart.yaml#L4) to [`7.0.12`](https://github.com/bitnami/charts/blob/f985538a832c556241bdc9d90cc7e6eb2c3686df/bitnami/redis/Chart.yaml#L8)
- Updates to new preferred [OCI-based container registry](https://helm.sh/docs/topics/registries/) for installations <sup>[1](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#installing-the-chart) [2](https://github.com/bitnami/charts/tree/main/bitnami/mariadb#installing-the-chart) [3](https://github.com/bitnami/charts/tree/main/bitnami/redis#installing-the-chart)</sup>

## Benefits

This puts us at the latest versions, so we aren't deploying a major version out of date. I haven't checked, but there may also be security patches that we would benefit from here.

## Possible drawbacks

⚠️ Users already having deployed the chart using our bundled `postgresql` bitnami sub-chart will need to upgrade their databases to stay current according to Bitnami's postgresql chart [README](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#to-1200) . Official upgrade instructions can be found [here](https://www.postgresql.org/docs/15/upgrading.html).

## Applicable issues

Don't think there's any right now.

## Additional information

Bumping major version of chart to account for major version bump of subcharts, but we can also do a minor version here as all of these are optional? Open to feedback on which number to bump.

Upgrade of Redis should not incur any extra work according to their README docs [here](https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1700).

MariaDB doesn't have a major appVersion bump so there's [no upgrade instructions listed](https://github.com/bitnami/charts/tree/main/bitnami/mariadb#upgrading).

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
