### PR TITLE
Do not define loadBalancerIP on service unless set in values

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 3.5.22
+version: 3.6.0
 appVersion: 27.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.0.1
+version: 4.1.0
 appVersion: 27.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -156,7 +156,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                       |
 | `cronjob.securityContext`                                  | Optional security context for cronjob                                                  | `nil`                      |
 | `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer (leave unset to omit)                     | ``                         |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                     | `""`                         |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
 | `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
 | `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -156,7 +156,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                       |
 | `cronjob.securityContext`                                  | Optional security context for cronjob                                                  | `nil`                      |
 | `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                            | `""`                         |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                           | `""`                       |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
 | `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
 | `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -156,7 +156,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                       |
 | `cronjob.securityContext`                                  | Optional security context for cronjob                                                  | `nil`                      |
 | `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                     | `""`                         |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                            | `""`                         |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
 | `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
 | `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -156,7 +156,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cronjob sidecar                            | `{}`                       |
 | `cronjob.securityContext`                                  | Optional security context for cronjob                                                  | `nil`                      |
 | `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                           | `nil`                      |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer (leave unset to omit)                     | ``                         |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
 | `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
 | `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: app
 spec:
   type: {{ .Values.service.type }}
-  {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}
   ports:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -368,7 +368,7 @@ cronjob:
 service:
   type: ClusterIP
   port: 8080
-  loadBalancerIP: nil
+  # loadBalancerIP: 203.0.113.42
   nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -368,7 +368,7 @@ cronjob:
 service:
   type: ClusterIP
   port: 8080
-  # loadBalancerIP: 203.0.113.42
+  loadBalancerIP: ""
   nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims


### PR DESCRIPTION
# Pull Request

## Description of the change

This PR sets the `.Values.service.loadBalancerIP` field as optional, and does not define it in the service if it's not set in the values.

This is because some `LoadBalancer` implementations allow or even require this value to remain unset, and while it may sometimes be fine to leave it set but blank, this could have unexpected impacts depending on your cluster configuration.

In particular, `MetalLB` will leave the service `<pending>` if the `loadBalancerIP` is set to `nil`, and hardcoding it to a value in the values breaks the ability for `MetalLB`'s IPAM tooling to be used for dynamic address allocation. I suspect other LoadBalancer implementations may have similar behaviors.

## Benefits

 The primary benefit is more flexible usage with more `LoadBalancer` implementations.

## Possible drawbacks

None I can think of, however I am open to discussion.
<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
 - fixes #428

## Additional information

For easy review on the output, here is the before and after:


## After - No LB set

Note how the `loadBalancerIP` is now gone when it's not defined, for more flexible usage.

```bash
$ helm template nextcloud . --set service.type=LoadBalancer | grep Service -A 15
kind: Service
metadata:
  name: nextcloud
  labels:
    app.kubernetes.io/name: nextcloud
    helm.sh/chart: nextcloud-3.6.0
    app.kubernetes.io/instance: nextcloud
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: app
spec:
  type: LoadBalancer
  ports:
  - port: 8080
    targetPort: 80
    protocol: TCP
    name: http
```

## After - LB Set

Note how the `loadBalancerIP` still works as before when it's defined, for full backward compatibility.

```bash
$ helm template nextcloud . --set service.type=LoadBalancer --set service.loadBalancerIP=1.2.3.4 | grep Service -A 15
kind: Service
metadata:
  name: nextcloud
  labels:
    app.kubernetes.io/name: nextcloud
    helm.sh/chart: nextcloud-3.6.0
    app.kubernetes.io/instance: nextcloud
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: app
spec:
  type: LoadBalancer
  loadBalancerIP: 1.2.3.4
  ports:
  - port: 8080
    targetPort: 80
    protocol: TCP
```

## After - Forcing Previous Behavior

And if you still wish to template out the field with `nil` in the value as before, that is still supported by explicitly setting to `nil`.

```bash
$ helm template nextcloud . --set service.type=LoadBalancer --set service.loadBalancerIP=nil | grep Service -A 15
kind: Service
metadata:
  name: nextcloud
  labels:
    app.kubernetes.io/name: nextcloud
    helm.sh/chart: nextcloud-3.5.22
    app.kubernetes.io/instance: nextcloud
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: app
spec:
  type: LoadBalancer
  loadBalancerIP: nil
  ports:
  - port: 8080
    targetPort: 80
    protocol: TCP
```

## Before

Note the `nil` in the `loadBalancerIP` field.

```bash
$ helm template nextcloud . --set service.type=LoadBalancer | grep Service -A 15
kind: Service
metadata:
  name: nextcloud
  labels:
    app.kubernetes.io/name: nextcloud
    helm.sh/chart: nextcloud-3.6.0
    app.kubernetes.io/instance: nextcloud
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: app
spec:
  type: LoadBalancer
  loadBalancerIP: nil
  ports:
  - port: 8080
    targetPort: 80
    protocol: TCP
    name: http
```

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
