### PR TITLE
add ability to pull an SMTP hostname from an existing kubernetes secret

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.1.1
+version: 4.2.0
 appVersion: 27.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.existingSecret.passwordKey`                     | Name of the key that contains the password                                             | `nil`                      |
 | `nextcloud.existingSecret.smtpUsernameKey`                 | Name of the key that contains the SMTP username                                        | `nil`                      |
 | `nextcloud.existingSecret.smtpPasswordKey`                 | Name of the key that contains the SMTP password                                        | `nil`                      |
+| `nextcloud.existingSecret.smtpHostKey`                     | Name of the key that contains the SMTP hostname                                        | `nil`                      |
 | `nextcloud.update`                                         | Trigger update if custom command is used                                               | `0`                        |
 | `nextcloud.containerPort`                                  | Customize container port when not running as root                                      | `80`                       |
 | `nextcloud.datadir`                                        | nextcloud data dir location                                                            | `/var/www/html/data`       |

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -191,14 +190,17 @@ Create environment variables used to configure the nextcloud container as well a
   value: {{ .Values.nextcloud.mail.fromAddress | quote }}
 - name: MAIL_DOMAIN
   value: {{ .Values.nextcloud.mail.domain | quote }}
-- name: SMTP_HOST
-  value: {{ .Values.nextcloud.mail.smtp.host | quote }}
 - name: SMTP_SECURE
   value: {{ .Values.nextcloud.mail.smtp.secure | quote }}
 - name: SMTP_PORT
   value: {{ .Values.nextcloud.mail.smtp.port | quote }}
 - name: SMTP_AUTHTYPE
   value: {{ .Values.nextcloud.mail.smtp.authtype | quote }}
+- name: SMTP_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
+      key: {{ .Values.nextcloud.existingSecret.smtpHostKey | default "smtp-host" }}
 - name: SMTP_NAME
   valueFrom:
     secretKeyRef:

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -24,5 +24,6 @@ data:
   {{- if .Values.nextcloud.mail.enabled }}
   smtp-username: {{ default "" .Values.nextcloud.mail.smtp.name | b64enc | quote }}
   smtp-password: {{ default "" .Values.nextcloud.mail.smtp.password | b64enc | quote }}
+  smtp-host: {{ default "" .Values.nextcloud.mail.smtp.host | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -83,6 +83,7 @@ nextcloud:
     # tokenKey: nextcloud-token
     # smtpUsernameKey: smtp-username
     # smtpPasswordKey: smtp-password
+    # smtpHostKey: smtp-host
   update: 0
   # If web server is not binding default port, you can define it
   containerPort: 80


### PR DESCRIPTION
# Pull Request

## Description of the change

Adds SMTP hostname as one of the keys in an existing secret you can specify.

You can now set: `nextcloud.existingSecret.smtpHost`

Example values.yaml:

```yaml
nextcloud:
  existingSecret:
    enabled: true
    smtpUsernameKey: smtpUser
    smtpPasswordKey:  smtpPassword
    smtpHostKey: smtpHostname
```

## Benefits

now you can keep your smtp hostname private and secure, allowing you to open source more of your values.yaml 

## Possible drawbacks

none that I can think of

## Applicable issues

- fixes #431 

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
