### PR TITLE
adopt netxcloud.containerport in FPM deployment, allow rootless nginx

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.2.1
+version: 4.3.0
 appVersion: 27.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -80,120 +80,122 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                  | Description                                                                            | Default                    |
-|------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------|
-| `image.repository`                                         | nextcloud Image name                                                                   | `nextcloud`                |
-| `image.flavor`                                             | nextcloud Image type (Options: apache, fpm)                                            | `apache`                   |
-| `image.tag`                                                | nextcloud Image tag                                                                    | `appVersion`               |
-| `image.pullPolicy`                                         | Image pull policy                                                                      | `IfNotPresent`             |
-| `image.pullSecrets`                                        | Specify image pull secrets                                                             | `nil`                      |
-| `replicaCount`                                             | Number of nextcloud pods to deploy                                                     | `1`                        |
-| `ingress.className`                                        | Name of the ingress class to use                                                       | `nil`                      |
-| `ingress.enabled`                                          | Enable use of ingress controllers                                                      | `false`                    |
-| `ingress.servicePort`                                      | Ingress' backend servicePort                                                           | `http`                     |
-| `ingress.annotations`                                      | An array of service annotations                                                        | `nil`                      |
-| `ingress.labels`                                           | An array of service labels                                                             | `nil`                      |
-| `ingress.path`                                             | The `Path` to use in Ingress' `paths`                                                  | `/`                        |
-| `ingress.pathType`                                         | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                   |
-| `ingress.tls`                                              | Ingress TLS configuration                                                              | `[]`                       |
-| `nextcloud.host`                                           | nextcloud host to create application URLs, updates trusted_domains at installation time only| `nextcloud.kube.home` |
-| `nextcloud.username`                                       | User of the application                                                                | `admin`                    |
-| `nextcloud.password`                                       | Application password                                                                   | `changeme`                 |
-| `nextcloud.existingSecret.enabled`                         | Whether to use an existing secret or not                                               | `false`                    |
-| `nextcloud.existingSecret.secretName`                      | Name of the existing secret                                                            | `nil`                      |
-| `nextcloud.existingSecret.usernameKey`                     | Name of the key that contains the username                                             | `nil`                      |
-| `nextcloud.existingSecret.passwordKey`                     | Name of the key that contains the password                                             | `nil`                      |
-| `nextcloud.existingSecret.smtpUsernameKey`                 | Name of the key that contains the SMTP username                                        | `nil`                      |
-| `nextcloud.existingSecret.smtpPasswordKey`                 | Name of the key that contains the SMTP password                                        | `nil`                      |
-| `nextcloud.existingSecret.smtpHostKey`                     | Name of the key that contains the SMTP hostname                                        | `nil`                      |
-| `nextcloud.update`                                         | Trigger update if custom command is used                                               | `0`                        |
-| `nextcloud.containerPort`                                  | Customize container port when not running as root                                      | `80`                       |
-| `nextcloud.datadir`                                        | nextcloud data dir location                                                            | `/var/www/html/data`       |
-| `nextcloud.mail.enabled`                                   | Whether to enable/disable email settings                                               | `false`                    |
-| `nextcloud.mail.fromAddress`                               | nextcloud mail send from field                                                         | `nil`                      |
-| `nextcloud.mail.domain`                                    | nextcloud mail domain                                                                  | `nil`                      |
-| `nextcloud.mail.smtp.host`                                 | SMTP hostname                                                                          | `nil`                      |
-| `nextcloud.mail.smtp.secure`                               | SMTP connection `ssl` or empty                                                         | `''`                       |
-| `nextcloud.mail.smtp.port`                                 | Optional SMTP port                                                                     | `nil`                      |
-| `nextcloud.mail.smtp.authtype`                             | SMTP authentication method                                                             | `LOGIN`                    |
-| `nextcloud.mail.smtp.name`                                 | SMTP username                                                                          | `''`                       |
-| `nextcloud.mail.smtp.password`                             | SMTP password                                                                          | `''`                       |
-| `nextcloud.configs`                                        | Config files created in `/var/www/html/config`                                         | `{}`                       |
-| `nextcloud.persistence.subPath`                            | Set the subPath for nextcloud to use in volume                                         | `nil`                      |
-| `nextcloud.phpConfigs`                                     | PHP Config files created in `/usr/local/etc/php/conf.d`                                | `{}`                       |
-| `nextcloud.defaultConfigs.\.htaccess`                      | Default .htaccess to protect `/var/www/html/config`                                    | `true`                     |
-| `nextcloud.defaultConfigs.redis\.config\.php`              | Default Redis configuration                                                            | `true`                     |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls                                          | `true`                     |
-| `nextcloud.defaultConfigs.apcu\.config\.php`               | Default configuration to define APCu as local cache                                    | `true`                     |
-| `nextcloud.defaultConfigs.apps\.config\.php`               | Default configuration for apps                                                         | `true`                     |
-| `nextcloud.defaultConfigs.autoconfig\.php`                 | Default auto-configuration for databases                                               | `true`                     |
-| `nextcloud.defaultConfigs.smtp\.config\.php`               | Default configuration for smtp                                                         | `true`                     |
-| `nextcloud.strategy`                                       | specifies the strategy used to replace old Pods by new ones                            | `type: Recreate`           |
-| `nextcloud.extraEnv`                                       | specify additional environment variables                                               | `{}`                       |
-| `nextcloud.extraSidecarContainers`                         | specify additional sidecar containers                                                  | `[]`                       |
-| `nextcloud.extraInitContainers`                            | specify additional init containers                                                     | `[]`                       |
-| `nextcloud.extraVolumes`                                   | specify additional volumes for the NextCloud pod                                       | `{}`                       |
-| `nextcloud.extraVolumeMounts`                              | specify additional volume mounts for the NextCloud pod                                 | `{}`                       |
-| `nextcloud.securityContext`                                | Optional security context for the NextCloud container                                  | `nil`                      |
-| `nextcloud.podSecurityContext`                             | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                      |
-| `nginx.enabled`                                            | Enable nginx (requires you use php-fpm image)                                          | `false`                    |
-| `nginx.image.repository`                                   | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container        | `nginx`                    |
-| `nginx.image.tag`                                          | nginx Image tag                                                                        | `alpine`                   |
-| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                | `IfNotPresent`             |
-| `nginx.config.default`                                     | Whether to use nextcloud's recommended nginx config                                    | `true`                     |
-| `nginx.config.custom`                                      | Specify a custom config for nginx                                                      | `{}`                       |
-| `nginx.resources`                                          | nginx resources                                                                        | `{}`                       |
-| `nginx.securityContext`                                    | Optional security context for the nginx container                                      | `nil`                      |
-| `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                     | `nil`                      |
-| `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                       | `nil`                      |
-| `redis.enabled`                                            | Whether to install/use redis for locking                                               | `false`                    |
-| `redis.auth.enabled`                                       | Whether to enable password authentication with redis                                   | `true`                     |
-| `redis.auth.password`                                      | The password redis uses                                                                | `''`                       |
-| `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                 | `''`                       |
-| `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                      | `''`                       |
-| `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                            | `false`                    |
-| `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar           | `nil`                      |
-| `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar             | `nil`                      |
-| `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cron jobs sidecar                          | `{}`                       |
-| `cronjob.securityContext`                                  | Optional security context for cron jobs sidecar                                          | `nil`                      |
-| `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                           | `""`                       |
-| `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
-| `service.ipFamilies`                                       | Set ipFamilies as in k8s service objects                                               | `nil`                      |
-| `service.ipFamyPolicy`                                     | define IP protocol bindings as in k8s service objects                                  | `nil`                      |
-| `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
-| `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |
-| `resources`                                                | CPU/Memory resource requests/limits                                                    | `{}`                       |
-| `rbac.enabled`                                             | Enable Role and rolebinding for priveledged PSP                                        | `false`                    |
-| `rbac.serviceaccount.create`                               | Wether to create a serviceaccount or use an existing one (requires rbac)               | `true`                     |
-| `rbac.serviceaccount.name`                                 | The name of the sevice account that the deployment will use (requires rbac)            | `nextcloud-serviceaccount` |
-| `rbac.serviceaccount.annotations`                          | Serviceaccount annotations                                                             | `{}`                       |
-| `livenessProbe.enabled`                                    | Turn on and off liveness probe                                                         | `true`                     |
-| `livenessProbe.initialDelaySeconds`                        | Delay before liveness probe is initiated                                               | `10`                       |
-| `livenessProbe.periodSeconds`                              | How often to perform the probe                                                         | `10`                       |
-| `livenessProbe.timeoutSeconds`                             | When the probe times out                                                               | `5`                        |
-| `livenessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                             | `3`                        |
-| `livenessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                            | `1`                        |
-| `readinessProbe.enabled`                                   | Turn on and off readiness probe                                                        | `true`                     |
-| `readinessProbe.initialDelaySeconds`                       | Delay before readiness probe is initiated                                              | `10`                       |
-| `readinessProbe.periodSeconds`                             | How often to perform the probe                                                         | `10`                       |
-| `readinessProbe.timeoutSeconds`                            | When the probe times out                                                               | `5`                        |
-| `readinessProbe.failureThreshold`                          | Minimum consecutive failures for the probe                                             | `3`                        |
-| `readinessProbe.successThreshold`                          | Minimum consecutive successes for the probe                                            | `1`                        |
-| `startupProbe.enabled`                                     | Turn on and off startup probe                                                          | `false`                    |
-| `startupProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                                              | `30`                       |
-| `startupProbe.periodSeconds`                               | How often to perform the probe                                                         | `10`                       |
-| `startupProbe.timeoutSeconds`                              | When the probe times out                                                               | `5`                        |
-| `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                             | `30`                       |
-| `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                            | `1`                        |
-| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                            | `false`                    |
-| `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                   | `60`                       |
-| `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                    | `1`                        |
-| `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                    | `10`                       |
-| `deploymentLabels`                                         | Labels to be added at 'deployment' level                                               | not set                    |
-| `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                          | not set                    |
-| `podLabels`                                                | Labels to be added at 'pod' level                                                      | not set                    |
-| `podAnnotations`                                           | Annotations to be added at 'pod' level                                                 | not set                    |
+| Parameter                                                  | Description                                                                                  | Default                    |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------------|----------------------------|
+| `image.repository`                                         | nextcloud Image name                                                                         | `nextcloud`                |
+| `image.flavor`                                             | nextcloud Image type (Options: apache, fpm)                                                  | `apache`                   |
+| `image.tag`                                                | nextcloud Image tag                                                                          | `appVersion`               |
+| `image.pullPolicy`                                         | Image pull policy                                                                            | `IfNotPresent`             |
+| `image.pullSecrets`                                        | Specify image pull secrets                                                                   | `nil`                      |
+| `replicaCount`                                             | Number of nextcloud pods to deploy                                                           | `1`                        |
+| `ingress.className`                                        | Name of the ingress class to use                                                             | `nil`                      |
+| `ingress.enabled`                                          | Enable use of ingress controllers                                                            | `false`                    |
+| `ingress.servicePort`                                      | Ingress' backend servicePort                                                                 | `http`                     |
+| `ingress.annotations`                                      | An array of service annotations                                                              | `nil`                      |
+| `ingress.labels`                                           | An array of service labels                                                                   | `nil`                      |
+| `ingress.path`                                             | The `Path` to use in Ingress' `paths`                                                        | `/`                        |
+| `ingress.pathType`                                         | The `PathType` to use in Ingress' `paths`                                                    | `Prefix`                   |
+| `ingress.tls`                                              | Ingress TLS configuration                                                                    | `[]`                       |
+| `nextcloud.host`                                           | nextcloud host to create application URLs, updates trusted_domains at installation time only | `nextcloud.kube.home`      |
+| `nextcloud.username`                                       | User of the application                                                                      | `admin`                    |
+| `nextcloud.password`                                       | Application password                                                                         | `changeme`                 |
+| `nextcloud.existingSecret.enabled`                         | Whether to use an existing secret or not                                                     | `false`                    |
+| `nextcloud.existingSecret.secretName`                      | Name of the existing secret                                                                  | `nil`                      |
+| `nextcloud.existingSecret.usernameKey`                     | Name of the key that contains the username                                                   | `nil`                      |
+| `nextcloud.existingSecret.passwordKey`                     | Name of the key that contains the password                                                   | `nil`                      |
+| `nextcloud.existingSecret.smtpUsernameKey`                 | Name of the key that contains the SMTP username                                              | `nil`                      |
+| `nextcloud.existingSecret.smtpPasswordKey`                 | Name of the key that contains the SMTP password                                              | `nil`                      |
+| `nextcloud.existingSecret.smtpHostKey`                     | Name of the key that contains the SMTP hostname                                              | `nil`                      |
+| `nextcloud.update`                                         | Trigger update if custom command is used                                                     | `0`                        |
+| `nextcloud.containerPort`                                  | Customize container port when not running as root                                            | `80`                       |
+| `nextcloud.datadir`                                        | nextcloud data dir location                                                                  | `/var/www/html/data`       |
+| `nextcloud.mail.enabled`                                   | Whether to enable/disable email settings                                                     | `false`                    |
+| `nextcloud.mail.fromAddress`                               | nextcloud mail send from field                                                               | `nil`                      |
+| `nextcloud.mail.domain`                                    | nextcloud mail domain                                                                        | `nil`                      |
+| `nextcloud.mail.smtp.host`                                 | SMTP hostname                                                                                | `nil`                      |
+| `nextcloud.mail.smtp.secure`                               | SMTP connection `ssl` or empty                                                               | `''`                       |
+| `nextcloud.mail.smtp.port`                                 | Optional SMTP port                                                                           | `nil`                      |
+| `nextcloud.mail.smtp.authtype`                             | SMTP authentication method                                                                   | `LOGIN`                    |
+| `nextcloud.mail.smtp.name`                                 | SMTP username                                                                                | `''`                       |
+| `nextcloud.mail.smtp.password`                             | SMTP password                                                                                | `''`                       |
+| `nextcloud.configs`                                        | Config files created in `/var/www/html/config`                                               | `{}`                       |
+| `nextcloud.persistence.subPath`                            | Set the subPath for nextcloud to use in volume                                               | `nil`                      |
+| `nextcloud.phpConfigs`                                     | PHP Config files created in `/usr/local/etc/php/conf.d`                                      | `{}`                       |
+| `nextcloud.defaultConfigs.\.htaccess`                      | Default .htaccess to protect `/var/www/html/config`                                          | `true`                     |
+| `nextcloud.defaultConfigs.redis\.config\.php`              | Default Redis configuration                                                                  | `true`                     |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls                                                | `true`                     |
+| `nextcloud.defaultConfigs.apcu\.config\.php`               | Default configuration to define APCu as local cache                                          | `true`                     |
+| `nextcloud.defaultConfigs.apps\.config\.php`               | Default configuration for apps                                                               | `true`                     |
+| `nextcloud.defaultConfigs.autoconfig\.php`                 | Default auto-configuration for databases                                                     | `true`                     |
+| `nextcloud.defaultConfigs.smtp\.config\.php`               | Default configuration for smtp                                                               | `true`                     |
+| `nextcloud.strategy`                                       | specifies the strategy used to replace old Pods by new ones                                  | `type: Recreate`           |
+| `nextcloud.extraEnv`                                       | specify additional environment variables                                                     | `{}`                       |
+| `nextcloud.extraSidecarContainers`                         | specify additional sidecar containers                                                        | `[]`                       |
+| `nextcloud.extraInitContainers`                            | specify additional init containers                                                           | `[]`                       |
+| `nextcloud.extraVolumes`                                   | specify additional volumes for the NextCloud pod                                             | `{}`                       |
+| `nextcloud.extraVolumeMounts`                              | specify additional volume mounts for the NextCloud pod                                       | `{}`                       |
+| `nextcloud.securityContext`                                | Optional security context for the NextCloud container                                        | `nil`                      |
+| `nextcloud.podSecurityContext`                             | Optional security context for the NextCloud pod (applies to all containers in the pod)       | `nil`                      |
+| `nginx.enabled`                                            | Enable nginx (requires you use php-fpm image)                                                | `false`                    |
+| `nginx.image.repository`                                   | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container              | `nginx`                    |
+| `nginx.image.tag`                                          | nginx Image tag                                                                              | `alpine`                   |
+| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                      | `IfNotPresent`             |
+| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                      | `IfNotPresent`             |
+| `nginx.image.containerPort`                                | Customize container port e.g. when not running as root                                       | `IfNotPresent`             |
+| `nginx.config.default`                                     | Whether to use nextcloud's recommended nginx config                                          | `true`                     |
+| `nginx.config.custom`                                      | Specify a custom config for nginx                                                            | `{}`                       |
+| `nginx.resources`                                          | nginx resources                                                                              | `{}`                       |
+| `nginx.securityContext`                                    | Optional security context for the nginx container                                            | `nil`                      |
+| `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                           | `nil`                      |
+| `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                             | `nil`                      |
+| `redis.enabled`                                            | Whether to install/use redis for locking                                                     | `false`                    |
+| `redis.auth.enabled`                                       | Whether to enable password authentication with redis                                         | `true`                     |
+| `redis.auth.password`                                      | The password redis uses                                                                      | `''`                       |
+| `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                       | `''`                       |
+| `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                            | `''`                       |
+| `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                  | `false`                    |
+| `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                 | `nil`                      |
+| `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                   | `nil`                      |
+| `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cron jobs sidecar                                | `{}`                       |
+| `cronjob.securityContext`                                  | Optional security context for cron jobs sidecar                                              | `nil`                      |
+| `service.type`                                             | Kubernetes Service type                                                                      | `ClusterIP`                |
+| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                                 | `""`                       |
+| `service.nodePort`                                         | NodePort for service type NodePort                                                           | `nil`                      |
+| `service.ipFamilies`                                       | Set ipFamilies as in k8s service objects                                                     | `nil`                      |
+| `service.ipFamyPolicy`                                     | define IP protocol bindings as in k8s service objects                                        | `nil`                      |
+| `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                            | `false`                    |
+| `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                            | `https`                    |
+| `resources`                                                | CPU/Memory resource requests/limits                                                          | `{}`                       |
+| `rbac.enabled`                                             | Enable Role and rolebinding for priveledged PSP                                              | `false`                    |
+| `rbac.serviceaccount.create`                               | Wether to create a serviceaccount or use an existing one (requires rbac)                     | `true`                     |
+| `rbac.serviceaccount.name`                                 | The name of the sevice account that the deployment will use (requires rbac)                  | `nextcloud-serviceaccount` |
+| `rbac.serviceaccount.annotations`                          | Serviceaccount annotations                                                                   | `{}`                       |
+| `livenessProbe.enabled`                                    | Turn on and off liveness probe                                                               | `true`                     |
+| `livenessProbe.initialDelaySeconds`                        | Delay before liveness probe is initiated                                                     | `10`                       |
+| `livenessProbe.periodSeconds`                              | How often to perform the probe                                                               | `10`                       |
+| `livenessProbe.timeoutSeconds`                             | When the probe times out                                                                     | `5`                        |
+| `livenessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                                   | `3`                        |
+| `livenessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                                  | `1`                        |
+| `readinessProbe.enabled`                                   | Turn on and off readiness probe                                                              | `true`                     |
+| `readinessProbe.initialDelaySeconds`                       | Delay before readiness probe is initiated                                                    | `10`                       |
+| `readinessProbe.periodSeconds`                             | How often to perform the probe                                                               | `10`                       |
+| `readinessProbe.timeoutSeconds`                            | When the probe times out                                                                     | `5`                        |
+| `readinessProbe.failureThreshold`                          | Minimum consecutive failures for the probe                                                   | `3`                        |
+| `readinessProbe.successThreshold`                          | Minimum consecutive successes for the probe                                                  | `1`                        |
+| `startupProbe.enabled`                                     | Turn on and off startup probe                                                                | `false`                    |
+| `startupProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                                                    | `30`                       |
+| `startupProbe.periodSeconds`                               | How often to perform the probe                                                               | `10`                       |
+| `startupProbe.timeoutSeconds`                              | When the probe times out                                                                     | `5`                        |
+| `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                   | `30`                       |
+| `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                  | `1`                        |
+| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                                  | `false`                    |
+| `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                         | `60`                       |
+| `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                          | `1`                        |
+| `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                          | `10`                       |
+| `deploymentLabels`                                         | Labels to be added at 'deployment' level                                                     | not set                    |
+| `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                                | not set                    |
+| `podLabels`                                                | Labels to be added at 'pod' level                                                            | not set                    |
+| `podAnnotations`                                           | Annotations to be added at 'pod' level                                                       | not set                    |
 
 
 ### Database Configurations

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -96,7 +96,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `ingress.path`                                             | The `Path` to use in Ingress' `paths`                                                  | `/`                        |
 | `ingress.pathType`                                         | The `PathType` to use in Ingress' `paths`                                              | `Prefix`                   |
 | `ingress.tls`                                              | Ingress TLS configuration                                                              | `[]`                       |
-| `nextcloud.host`                                           | nextcloud host to create application URLs                                              | `nextcloud.kube.home`      |
+| `nextcloud.host`                                           | nextcloud host to create application URLs, updates trusted_domains at installation time only| `nextcloud.kube.home` |
 | `nextcloud.username`                                       | User of the application                                                                | `admin`                    |
 | `nextcloud.password`                                       | Application password                                                                   | `changeme`                 |
 | `nextcloud.existingSecret.enabled`                         | Whether to use an existing secret or not                                               | `false`                    |
@@ -137,7 +137,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.securityContext`                                | Optional security context for the NextCloud container                                  | `nil`                      |
 | `nextcloud.podSecurityContext`                             | Optional security context for the NextCloud pod (applies to all containers in the pod) | `nil`                      |
 | `nginx.enabled`                                            | Enable nginx (requires you use php-fpm image)                                          | `false`                    |
-| `nginx.image.repository`                                   | nginx Image name                                                                       | `nginx`                    |
+| `nginx.image.repository`                                   | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container        | `nginx`                    |
 | `nginx.image.tag`                                          | nginx Image tag                                                                        | `alpine`                   |
 | `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                | `IfNotPresent`             |
 | `nginx.config.default`                                     | Whether to use nextcloud's recommended nginx config                                    | `true`                     |
@@ -159,6 +159,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `service.type`                                             | Kubernetes Service type                                                                | `ClusterIP`                |
 | `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                           | `""`                       |
 | `service.nodePort`                                         | NodePort for service type NodePort                                                     | `nil`                      |
+| `service.ipFamilies`                                       | Set ipFamilies as in k8s service objects                                               | `nil`                      |
+| `service.ipFamyPolicy`                                     | define IP protocol bindings as in k8s service objects                                  | `nil`                      |
 | `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `false`                    |
 | `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                      | `https`                    |
 | `resources`                                                | CPU/Memory resource requests/limits                                                    | `{}`                       |

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -32,7 +32,7 @@
         }
 
         server {
-            listen {{ .Values.nextcloud.containerPort }};
+            listen {{ .Values.nginx.containerPort }};
 
             # HSTS settings
             # WARNING: Only add the preload option once you read about

--- a/charts/nextcloud/templates/nginx-config.yaml
+++ b/charts/nextcloud/templates/nginx-config.yaml
@@ -1,20 +1,8 @@
-{{- if .Values.nginx.enabled -}}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "nextcloud.fullname" . }}-nginxconfig
-  labels:
-    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
-    helm.sh/chart: {{ include "nextcloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-data:
-  nginx.conf: |-
-{{- if .Values.nginx.config.default }}
+{{- define "nginx.conf" }}
     worker_processes auto;
 
     error_log  /var/log/nginx/error.log warn;
-    pid        /var/run/nginx.pid;
+    pid        /tmp/nginx.pid;
 
 
     events {
@@ -44,7 +32,7 @@ data:
         }
 
         server {
-            listen 80;
+            listen {{ .Values.nextcloud.containerPort }};
 
             # HSTS settings
             # WARNING: Only add the preload option once you read about
@@ -172,6 +160,22 @@ data:
             }
         }
     }
+{{- end }}
+
+{{- if .Values.nginx.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-nginxconfig
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  nginx.conf: |-
+{{- if .Values.nginx.config.default }}
+    {{- template "nginx.conf" $ }}
 {{- else }}
 {{ .Values.nginx.config.custom | indent 4 }}
 {{- end }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -13,6 +13,13 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: 
+  {{- toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.nextcloud.containerPort }}


### PR DESCRIPTION
# Pull Request

## Description of the change

is `netxcloud.containerport` is set, it will also configure the port for nginx. This allows nginx running in a rootless container e.g. by using their official `nginxinc/nginx-unprivileged` image. pid is written to /tmp for that reason.
Some enhanced configs parameter for service.


## Benefits
rootless nginx conaiiner. 

## Possible drawbacks

the nginx port will switch to `netxcloud.containerport` in FPM installations, but this should be
1. very rare, because `netxcloud.containerport` should not be changed 
2. even if changed the service will automatically connect to the changed port.

## Applicable issues
N/A

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] (optional) Variables are documented in the README.md
