### PR TITLE
Only set REDIS_HOST_PASSWORD when Redis auth is enabled

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.3.3
+version: 4.3.4
 appVersion: 27.1.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -217,6 +217,7 @@ Create environment variables used to configure the nextcloud container as well a
   value: {{ template "nextcloud.redis.fullname" . }}-master
 - name: REDIS_HOST_PORT
   value: {{ .Values.redis.master.service.ports.redis | quote }}
+{{- if .Values.redis.auth.enabled }}
 {{- if and .Values.redis.auth.existingSecret .Values.redis.auth.existingSecretPasswordKey }}
 - name: REDIS_HOST_PASSWORD
   valueFrom:
@@ -226,6 +227,7 @@ Create environment variables used to configure the nextcloud container as well a
 {{- else }}
 - name: REDIS_HOST_PASSWORD
   value: {{ .Values.redis.auth.password }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.nextcloud.extraEnv }}


### PR DESCRIPTION
# Pull Request

## Description of the change

`REDIS_HOST_PASSWORD` is only set when Redis authentication is turned on.

## Benefits

Because of the container's entrypoint, Redis setup without authentication only works when the environment variable  `REDIS_HOST_PASSWORD` is not set at all (cf. https://github.com/nextcloud/docker/blob/master/docker-entrypoint.sh#L122). Previously, the chart only allowed for setting it as an empty string which is not enough and leads to a broken Redis connection string.

## Possible drawbacks

None I could think of.

## Applicable issues

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
