### PR TITLE
Don't set redis pw when redis auth is disabled

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.3.4
+version: 4.3.5
 appVersion: 27.1.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/config.yaml
+++ b/charts/nextcloud/templates/config.yaml
@@ -39,7 +39,9 @@ data:
         'redis' => array(
           'host' => getenv('REDIS_HOST'),
           'port' => getenv('REDIS_HOST_PORT') ?: 6379,
+{{- if .Values.redis.auth.enabled }}
           'password' => getenv('REDIS_HOST_PASSWORD'),
+{{- end }}
         ),
       );
     }


### PR DESCRIPTION
# Pull Request

## Description of the change

This allows for the usage of the default redis.config.php when disabling Redis authentication. When redis.auth is disabled, the line with 'password' is not included.

## Benefits

No need to use a custom redis.config.php.

## Possible drawbacks

-

## Applicable issues

-

## Additional information



## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
