### PR TITLE
[metrics] use token or user/pwd from existing secret

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.3.7
+version: 4.3.6-patch2
 appVersion: 27.1.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.3.6
+version: 4.3.7
 appVersion: 27.1.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -51,7 +51,7 @@ We also package the following helm charts from Bitnami for you to _optionally_ u
 
 - Kubernetes 1.24+
 - Persistent Volume provisioner support in the underlying infrastructure
-- Helm >=3.7.0 ([for subchart scope exposing](nextcloud/helm#152))
+- Helm >=3.7.0 ([for subchart scope exposing](https://github.com/nextcloud/helm/pull/152))
 
 ## Installing the Chart
 
@@ -153,6 +153,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `redis.auth.password`                                      | The password redis uses                                                                      | `''`                       |
 | `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                       | `''`                       |
 | `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                            | `''`                       |
+| `systemCron.enabled`                                                 | Whether to enable/disable system cronjob that runs inside the main pod                 | `false`                                      |
 | `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                  | `false`                    |
 | `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                 | `nil`                      |
 | `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                   | `nil`                      |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -276,7 +276,8 @@ We include an optional experimental Nextcloud Metrics exporter from [xperimental
 |----------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `metrics.enabled`                      | Start Prometheus metrics exporter                                            | `false`                                                      |
 | `metrics.https`                        | Defines if https is used to connect to nextcloud                             | `false` (uses http)                                          |
-| `metrics.token`                        | Uses token for auth instead of username/password                             | `""`                                                         |
+| `metrics.token`                        | Uses token for auth instead of username/password or existing secret          | `""`                                                         |
+| `metrics.existingSecret.secretName`    | Name of a secret that contains `NEXTCLOUD_AUTH_TOKEN` or `NEXTCLOUD_USERNAME` and `NEXTCLOUD_PASSWORD`                             | `nil`                                                         |
 | `metrics.timeout`                      | When the scrape times out                                                    | `5s`                                                         |
 | `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                           | `false`                                                      |
 | `metrics.image.repository`             | Nextcloud metrics exporter image name                                        | `xperimental/nextcloud-exporter`                             |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -56,6 +56,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: {{ include "nextcloud.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.systemCron.enabled }}
+        command:
+          - "/bin/sh"
+          - "-c"
+          - "busybox crond -l 0 -L /dev/stdout ; /entrypoint.sh apache2-foreground"
+        {{- end }}
         {{- if .Values.lifecycle }}
         lifecycle:
         {{-   if .Values.lifecycle.postStartCommand }}

--- a/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/charts/nextcloud/templates/metrics-deployment.yaml
@@ -37,7 +37,13 @@ spec:
       - name: metrics-exporter
         image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+        {{- if .Values.metrics.existingSecret }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.metrics.existingSecret.secretName }}
+        {{- end }}
         env:
+        {{- if not .Values.metrics.existingSecret }}
         {{- if .Values.metrics.token }}
         - name: NEXTCLOUD_AUTH_TOKEN
           valueFrom:
@@ -55,6 +61,7 @@ spec:
             secretKeyRef:
               name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
               key: {{ .Values.nextcloud.existingSecret.passwordKey | default "nextcloud-password" }}
+        {{- end }}
         {{- end }}
         # NEXTCLOUD_SERVER is used by metrics-exporter to reach the Nextcloud (K8s-)Service to grab the serverinfo api endpoint
         - name: NEXTCLOUD_SERVER

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -470,10 +470,21 @@ metrics:
   replicaCount: 1
   # The metrics exporter needs to know how you serve Nextcloud either http or https
   https: false
-  # Use API token if set, otherwise fall back to password authentication
+  # Use API token if set, otherwise fall back to password authentication or use
+  # an existing secret
   # https://github.com/xperimental/nextcloud-exporter#token-authentication
   # Currently you still need to set the token manually in your nextcloud install
   token: ""
+
+  # Instead of the token above you can also use the token from an existing secret
+  existingSecret:
+    # Names of secret to use for Nextcloud Metrics credentials.
+    # The secret keys will be mounted as env-vars:
+    #   * To set the token use `NEXTCLOUD_AUTH_TOKEN`
+    #   * but you can also set `NEXTCLOUD_USERNAME` and `NEXTCLOUD_PASSWORD`
+    # See https://github.com/xperimental/nextcloud-exporter#environment-variables
+    secretName: ""
+
   timeout: 5s
   # if set to true, exporter skips certificate verification of Nextcloud server.
   tlsSkipVerify: false

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -344,6 +344,11 @@ redis:
     existingSecretPasswordKey: ""
 
 
+systemCron: # run a system cron job inside the nextcloud image
+  # https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron
+  enabled: false
+
+
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron
 ##


### PR DESCRIPTION
# Pull Request

## Description of the change

Add a new field to the helm-chart that enables usage of an existing secret for the metrics credentials

## Benefits

see above

## Possible drawbacks

None expected. The change is backwards compatible

## Applicable issues

none

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
