### PR TITLE
Update issue.md - add note about syntax highlighting

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -25,6 +25,7 @@ assignees: ''
 
 - `values.yaml`:
 
+<!-- please keep the ```yaml part here, as it creates syntax highlighting to help with reading the file -->
 ```yaml
 # paste your values.yaml (anonymize any sensitive data)
 ```


### PR DESCRIPTION
# Pull Request

## Description of the change

Adds polite note about keeping the <code>```yaml</code> in place, because I can't read so great and it _really_ helps me.

## Benefits

Maybe some users remove this by accident or because they think it is just left over by accident and this will help them.

## Possible drawbacks

slightly longer issue template by one line :P

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
