### PR TITLE
Sync config files from nextcloud/docker repo; Add S3/Swift object storage config; Add S3 ci test; Add `nextcloud.trustedDomains`

### DIFF
--- a/.github/tests/minio_test_values.yaml
+++ b/.github/tests/minio_test_values.yaml
@@ -1,0 +1,23 @@
+## minio helm chart values for use in ci tests:
+# https://github.com/minio/minio/blob/master/helm/minio/values.yaml
+
+# make service name predictable
+fullnameOverride: minio
+
+## minio mode, i.e. standalone or distributed
+mode: standalone
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests:
+    memory: 1Gi
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+persistence:
+  enabled: false
+
+# default credentials
+rootUser: nextcloud
+rootPassword: rootpass123

--- a/.github/tests/test_upload_job.yaml
+++ b/.github/tests/test_upload_job.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-nextcloud-file
+  namespace: nextcloud
+spec:
+  template:
+    metadata:
+      name: create-nextcloud-file
+    spec:
+      containers:
+        - name: create-nextcloud-file
+          image: curlimages/curl
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "testing123" > test_upload.txt && \
+              curl \
+                -w "%{http_code}" \
+                -u admin:changeme \
+                -T test_upload.txt \
+              "http://nextcloud.nextcloud.svc.cluster.local:8080/remote.php/dav/files/admin/test_upload.txt" && \
+              echo -e "\nTried to uploaded a file, test_upload.txt, to Nextcloud."
+      restartPolicy: Never

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
-  run-tests:
+  test:
     runs-on: ubuntu-22.04
     needs: [changes, lint]
     # only run this job if there are helm chart file changes
@@ -81,6 +81,12 @@ jobs:
           # test the helm chart with horizontal pod autoscaling enabled
           - name: Horizontal Pod Autoscaling Enabled
             helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=2 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+
+          # test the helm chart with s3 as the primary storage
+          - name: S3 Enabled as Primary Storage
+            # we need to skip the clean up so we can test adding a file
+            helm_args: |
+                --namespace nextcloud --skip-clean-up --helm-extra-set-args "--set=fullnameOverride=nextcloud --set=nextcloud.objectStore.s3.enabled=true --set=nextcloud.objectStore.s3.accessKey=nextcloud --set=nextcloud.objectStore.s3.secretKey=rootpass123 --set=nextcloud.objectStore.s3.host=minio.nextcloud.svc.cluster.local --set=nextcloud.objectStore.s3.port=9000 --set=nextcloud.objectStore.s3.ssl=false --set=nextcloud.objectStore.s3.bucket=nextcloud --set=nextcloud.objectStore.s3.usePathStyle=true --set=image.flavor=fpm --set=nginx.enabled=true --set=nextcloud.host=nextcloud --set=nextcloud.trustedDomains[0]='*'"
 
     steps:
       - name: Checkout
@@ -112,15 +118,43 @@ jobs:
         uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install MinIO for testing S3 as Primary Storage
+        if: matrix.test_cases.name == 'S3 Enabled as Primary Storage'
+        # installs minio community helm chart here:
+        # https://github.com/minio/minio/tree/master/helm/minio
+        run: |
+          helm repo add minio https://charts.min.io/ && \
+          helm install minio \
+             --namespace nextcloud \
+             --create-namespace \
+             --wait \
+             --wait-for-jobs \
+             --timeout 2m0s \
+             --values .github/tests/minio_test_values.yaml \
+             minio/minio
+
       - name: Run chart-testing (install ${{ matrix.test_cases.name }})
         id: install
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} ${{ matrix.test_cases.helm_args }}
 
+      - name: Try adding a file to Nextcloud
+        if: matrix.test_cases.name == 'S3 Enabled as Primary Storage'
+        # applies a kubernetes job that uploads a file and then checks log of finished pod
+        run: |
+            kubectl config set-context --current --namespace=nextcloud && \
+            kubectl apply -f ./.github/tests/test_upload_job.yaml --wait=true && \
+            sleep 2 && \
+            kubectl wait --for=condition=Complete --timeout=2m job/create-nextcloud-file && \
+            echo "Here's the logs from the job:" && \
+            kubectl logs --tail=-1 -f -l batch.kubernetes.io/job-name=create-nextcloud-file && \
+            echo "Here's the logs from the nextcloud pod:" && \
+            kubectl logs -l app.kubernetes.io/name=nextcloud
+
   summary:
     runs-on: ubuntu-latest-low
-    needs: [changes, run-tests]
+    needs: [changes, test]
     if: always()
     steps:
       - name: Summary
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.run-tests.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.test.result != 'success' }}; then exit 1; fi

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.3.2
+version: 5.4.0
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -17,9 +17,11 @@ helm install my-release nextcloud/nextcloud
 * [Uninstalling the Chart](#uninstalling-the-chart)
 * [Configuration](#configuration)
     * [Database Configurations](#database-configurations)
+    * [Object Storage as Primary Storage Configuration](#object-storage-as-primary-storage-configuration)
     * [Persistence Configurations](#persistence-configurations)
     * [Metrics Configurations](#metrics-configurations)
 * [Cron jobs](#cron-jobs)
+* [Using the nextcloud docker image auto-configuration via env vars](#using-the-nextcloud-docker-image-auto-configuration-via-env-vars)
 * [Multiple config.php file](#multiple-configphp-file)
 * [Using nginx](#using-nginx)
     * [Service discovery with nginx and ingress](#service-discovery-with-nginx-and-ingress)
@@ -90,129 +92,132 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                  | Description                                                                                         | Default                    |
-|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|----------------------------|
-| `image.repository`                                         | nextcloud Image name                                                                                | `nextcloud`                |
-| `image.flavor`                                             | nextcloud Image type (Options: apache, fpm)                                                         | `apache`                   |
-| `image.tag`                                                | nextcloud Image tag                                                                                 | `appVersion`               |
-| `image.pullPolicy`                                         | Image pull policy                                                                                   | `IfNotPresent`             |
-| `image.pullSecrets`                                        | Specify image pull secrets                                                                          | `nil`                      |
-| `replicaCount`                                             | Number of nextcloud pods to deploy                                                                  | `1`                        |
-| `ingress.className`                                        | Name of the ingress class to use                                                                    | `nil`                      |
-| `ingress.enabled`                                          | Enable use of ingress controllers                                                                   | `false`                    |
-| `ingress.servicePort`                                      | Ingress' backend servicePort                                                                        | `http`                     |
-| `ingress.annotations`                                      | An array of service annotations                                                                     | `nil`                      |
-| `ingress.labels`                                           | An array of service labels                                                                          | `nil`                      |
-| `ingress.path`                                             | The `Path` to use in Ingress' `paths`                                                               | `/`                        |
-| `ingress.pathType`                                         | The `PathType` to use in Ingress' `paths`                                                           | `Prefix`                   |
-| `ingress.tls`                                              | Ingress TLS configuration                                                                           | `[]`                       |
-| `nextcloud.host`                                           | nextcloud host to create application URLs, updates trusted_domains at installation time only        | `nextcloud.kube.home`      |
-| `nextcloud.username`                                       | User of the application                                                                             | `admin`                    |
-| `nextcloud.password`                                       | Application password                                                                                | `changeme`                 |
-| `nextcloud.existingSecret.enabled`                         | Whether to use an existing secret or not                                                            | `false`                    |
-| `nextcloud.existingSecret.secretName`                      | Name of the existing secret                                                                         | `nil`                      |
-| `nextcloud.existingSecret.usernameKey`                     | Name of the key that contains the username                                                          | `nil`                      |
-| `nextcloud.existingSecret.passwordKey`                     | Name of the key that contains the password                                                          | `nil`                      |
-| `nextcloud.existingSecret.smtpUsernameKey`                 | Name of the key that contains the SMTP username                                                     | `nil`                      |
-| `nextcloud.existingSecret.smtpPasswordKey`                 | Name of the key that contains the SMTP password                                                     | `nil`                      |
-| `nextcloud.existingSecret.smtpHostKey`                     | Name of the key that contains the SMTP hostname                                                     | `nil`                      |
-| `nextcloud.update`                                         | Trigger update if custom command is used                                                            | `0`                        |
-| `nextcloud.containerPort`                                  | Customize container port when not running as root                                                   | `80`                       |
-| `nextcloud.datadir`                                        | nextcloud data dir location                                                                         | `/var/www/html/data`       |
-| `nextcloud.mail.enabled`                                   | Whether to enable/disable email settings                                                            | `false`                    |
-| `nextcloud.mail.fromAddress`                               | nextcloud mail send from field                                                                      | `nil`                      |
-| `nextcloud.mail.domain`                                    | nextcloud mail domain                                                                               | `nil`                      |
-| `nextcloud.mail.smtp.host`                                 | SMTP hostname                                                                                       | `nil`                      |
-| `nextcloud.mail.smtp.secure`                               | SMTP connection `ssl` or empty                                                                      | `''`                       |
-| `nextcloud.mail.smtp.port`                                 | Optional SMTP port                                                                                  | `nil`                      |
-| `nextcloud.mail.smtp.authtype`                             | SMTP authentication method                                                                          | `LOGIN`                    |
-| `nextcloud.mail.smtp.name`                                 | SMTP username, ONLY the part before the domain name. i.e. 'postmaster' NOT 'postmaster@example.com' | `''`                       |
-| `nextcloud.mail.smtp.password`                             | SMTP password                                                                                       | `''`                       |
-| `nextcloud.configs`                                        | Config files created in `/var/www/html/config`                                                      | `{}`                       |
-| `nextcloud.persistence.subPath`                            | Set the subPath for nextcloud to use in volume                                                      | `nil`                      |
-| `nextcloud.phpConfigs`                                     | PHP Config files created in `/usr/local/etc/php/conf.d`                                             | `{}`                       |
-| `nextcloud.defaultConfigs.\.htaccess`                      | Default .htaccess to protect `/var/www/html/config`                                                 | `true`                     |
-| `nextcloud.defaultConfigs.redis\.config\.php`              | Default Redis configuration                                                                         | `true`                     |
-| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls                                                       | `true`                     |
-| `nextcloud.defaultConfigs.apcu\.config\.php`               | Default configuration to define APCu as local cache                                                 | `true`                     |
-| `nextcloud.defaultConfigs.apps\.config\.php`               | Default configuration for apps                                                                      | `true`                     |
-| `nextcloud.defaultConfigs.autoconfig\.php`                 | Default auto-configuration for databases                                                            | `true`                     |
-| `nextcloud.defaultConfigs.smtp\.config\.php`               | Default configuration for smtp                                                                      | `true`                     |
-| `nextcloud.strategy`                                       | specifies the strategy used to replace old Pods by new ones                                         | `type: Recreate`           |
-| `nextcloud.extraEnv`                                       | specify additional environment variables                                                            | `{}`                       |
-| `nextcloud.extraSidecarContainers`                         | specify additional sidecar containers                                                               | `[]`                       |
-| `nextcloud.extraInitContainers`                            | specify additional init containers                                                                  | `[]`                       |
-| `nextcloud.extraVolumes`                                   | specify additional volumes for the NextCloud pod                                                    | `{}`                       |
-| `nextcloud.extraVolumeMounts`                              | specify additional volume mounts for the NextCloud pod                                              | `{}`                       |
-| `nextcloud.securityContext`                                | Optional security context for the NextCloud container                                               | `nil`                      |
-| `nextcloud.podSecurityContext`                             | Optional security context for the NextCloud pod (applies to all containers in the pod)              | `nil`                      |
-| `nginx.enabled`                                            | Enable nginx (requires you use php-fpm image)                                                       | `false`                    |
-| `nginx.image.repository`                                   | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container                     | `nginx`                    |
-| `nginx.image.tag`                                          | nginx Image tag                                                                                     | `alpine`                   |
-| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                             | `IfNotPresent`             |
-| `nginx.image.pullPolicy`                                   | nginx Image pull policy                                                                             | `IfNotPresent`             |
-| `nginx.containerPort`                                      | Customize container port e.g. when not running as root                                              | `IfNotPresent`             |
-| `nginx.config.default`                                     | Whether to use nextcloud's recommended nginx config                                                 | `true`                     |
-| `nginx.config.custom`                                      | Specify a custom config for nginx                                                                   | `{}`                       |
-| `nginx.resources`                                          | nginx resources                                                                                     | `{}`                       |
-| `nginx.securityContext`                                    | Optional security context for the nginx container                                                   | `nil`                      |
-| `nginx.extraEnv`                                           | Optional environment variables for the nginx container                                              | `nil`                      |
-| `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                                  | `nil`                      |
-| `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                                    | `nil`                      |
-| `redis.enabled`                                            | Whether to install/use redis for locking                                                            | `false`                    |
-| `redis.auth.enabled`                                       | Whether to enable password authentication with redis                                                | `true`                     |
-| `redis.auth.password`                                      | The password redis uses                                                                             | `''`                       |
-| `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                              | `''`                       |
-| `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                                   | `''`                       |
-| `redis.global.storageClass`                                | PVC Storage Class  for both Redis&reg; master and replica Persistent Volumes                        | `''`                       |
-| `redis.master.persistence.enabled`                         | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                        | `true`                     |
-| `redis.replica.persistence.enabled`                        | Enable persistence on Redis&reg; replica nodes using Persistent Volume Claims                       | `true`                     |
-| `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                         | `false`                    |
-| `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                        | `nil`                      |
-| `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                          | `nil`                      |
-| `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cron jobs sidecar                                       | `{}`                       |
-| `cronjob.securityContext`                                  | Optional security context for cron jobs sidecar                                                     | `nil`                      |
-| `service.type`                                             | Kubernetes Service type                                                                             | `ClusterIP`                |
-| `service.loadBalancerIP`                                   | LoadBalancerIp for service type LoadBalancer                                                        | `""`                       |
-| `service.annotations`                                      | Annotations for service type                                                                        | `{}`                       |
-| `service.nodePort`                                         | NodePort for service type NodePort                                                                  | `nil`                      |
-| `service.ipFamilies`                                       | Set ipFamilies as in k8s service objects                                                            | `nil`                      |
-| `service.ipFamyPolicy`                                     | define IP protocol bindings as in k8s service objects                                               | `nil`                      |
-| `phpClientHttpsFix.enabled`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `false`                    |
-| `phpClientHttpsFix.protocol`                               | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `https`                    |
-| `resources`                                                | CPU/Memory resource requests/limits                                                                 | `{}`                       |
-| `rbac.enabled`                                             | Enable Role and rolebinding for priveledged PSP                                                     | `false`                    |
-| `rbac.serviceaccount.create`                               | Wether to create a serviceaccount or use an existing one (requires rbac)                            | `true`                     |
-| `rbac.serviceaccount.name`                                 | The name of the sevice account that the deployment will use (requires rbac)                         | `nextcloud-serviceaccount` |
-| `rbac.serviceaccount.annotations`                          | Serviceaccount annotations                                                                          | `{}`                       |
-| `livenessProbe.enabled`                                    | Turn on and off liveness probe                                                                      | `true`                     |
-| `livenessProbe.initialDelaySeconds`                        | Delay before liveness probe is initiated                                                            | `10`                       |
-| `livenessProbe.periodSeconds`                              | How often to perform the probe                                                                      | `10`                       |
-| `livenessProbe.timeoutSeconds`                             | When the probe times out                                                                            | `5`                        |
-| `livenessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                                          | `3`                        |
-| `livenessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `readinessProbe.enabled`                                   | Turn on and off readiness probe                                                                     | `true`                     |
-| `readinessProbe.initialDelaySeconds`                       | Delay before readiness probe is initiated                                                           | `10`                       |
-| `readinessProbe.periodSeconds`                             | How often to perform the probe                                                                      | `10`                       |
-| `readinessProbe.timeoutSeconds`                            | When the probe times out                                                                            | `5`                        |
-| `readinessProbe.failureThreshold`                          | Minimum consecutive failures for the probe                                                          | `3`                        |
-| `readinessProbe.successThreshold`                          | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `startupProbe.enabled`                                     | Turn on and off startup probe                                                                       | `false`                    |
-| `startupProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                                                           | `30`                       |
-| `startupProbe.periodSeconds`                               | How often to perform the probe                                                                      | `10`                       |
-| `startupProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
-| `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `30`                       |
-| `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
-| `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
-| `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
-| `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `10`                       |
-| `deploymentLabels`                                         | Labels to be added at 'deployment' level                                                            | not set                    |
-| `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                                       | not set                    |
-| `podLabels`                                                | Labels to be added at 'pod' level                                                                   | not set                    |
-| `podAnnotations`                                           | Annotations to be added at 'pod' level                                                              | not set                    |
-| `dnsConfig`                                                | Custom dnsConfig for nextcloud containers                                                           | `{}`                       |
-
+| Parameter                                                   | Description                                                                                         | Default                    |
+|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|----------------------------|
+| `image.repository`                                          | nextcloud Image name                                                                                | `nextcloud`                |
+| `image.flavor`                                              | nextcloud Image type (Options: apache, fpm)                                                         | `apache`                   |
+| `image.tag`                                                 | nextcloud Image tag                                                                                 | `appVersion`               |
+| `image.pullPolicy`                                          | Image pull policy                                                                                   | `IfNotPresent`             |
+| `image.pullSecrets`                                         | Specify image pull secrets                                                                          | `nil`                      |
+| `replicaCount`                                              | Number of nextcloud pods to deploy                                                                  | `1`                        |
+| `ingress.className`                                         | Name of the ingress class to use                                                                    | `nil`                      |
+| `ingress.enabled`                                           | Enable use of ingress controllers                                                                   | `false`                    |
+| `ingress.servicePort`                                       | Ingress' backend servicePort                                                                        | `http`                     |
+| `ingress.annotations`                                       | An array of service annotations                                                                     | `nil`                      |
+| `ingress.labels`                                            | An array of service labels                                                                          | `nil`                      |
+| `ingress.path`                                              | The `Path` to use in Ingress' `paths`                                                               | `/`                        |
+| `ingress.pathType`                                          | The `PathType` to use in Ingress' `paths`                                                           | `Prefix`                   |
+| `ingress.tls`                                               | Ingress TLS configuration                                                                           | `[]`                       |
+| `nextcloud.host`                                            | nextcloud host to create application URLs, updates trusted_domains at installation time only        | `nextcloud.kube.home`      |
+| `nextcloud.username`                                        | User of the application                                                                             | `admin`                    |
+| `nextcloud.password`                                        | Application password                                                                                | `changeme`                 |
+| `nextcloud.existingSecret.enabled`                          | Whether to use an existing secret or not                                                            | `false`                    |
+| `nextcloud.existingSecret.secretName`                       | Name of the existing secret                                                                         | `nil`                      |
+| `nextcloud.existingSecret.usernameKey`                      | Name of the key that contains the username                                                          | `nil`                      |
+| `nextcloud.existingSecret.passwordKey`                      | Name of the key that contains the password                                                          | `nil`                      |
+| `nextcloud.existingSecret.smtpUsernameKey`                  | Name of the key that contains the SMTP username                                                     | `nil`                      |
+| `nextcloud.existingSecret.smtpPasswordKey`                  | Name of the key that contains the SMTP password                                                     | `nil`                      |
+| `nextcloud.existingSecret.smtpHostKey`                      | Name of the key that contains the SMTP hostname                                                     | `nil`                      |
+| `nextcloud.update`                                          | Trigger update if custom command is used                                                            | `0`                        |
+| `nextcloud.containerPort`                                   | Customize container port when not running as root                                                   | `80`                       |
+| `nextcloud.datadir`                                         | nextcloud data dir location                                                                         | `/var/www/html/data`       |
+| `nextcloud.mail.enabled`                                    | Whether to enable/disable email settings                                                            | `false`                    |
+| `nextcloud.mail.fromAddress`                                | nextcloud mail send from field                                                                      | `nil`                      |
+| `nextcloud.mail.domain`                                     | nextcloud mail domain                                                                               | `nil`                      |
+| `nextcloud.mail.smtp.host`                                  | SMTP hostname                                                                                       | `nil`                      |
+| `nextcloud.mail.smtp.secure`                                | SMTP connection `ssl` or empty                                                                      | `''`                       |
+| `nextcloud.mail.smtp.port`                                  | Optional SMTP port                                                                                  | `nil`                      |
+| `nextcloud.mail.smtp.authtype`                              | SMTP authentication method                                                                          | `LOGIN`                    |
+| `nextcloud.mail.smtp.name`                                  | SMTP username, ONLY the part before the domain name. i.e. 'postmaster' NOT 'postmaster@example.com' | `''`                       |
+| `nextcloud.mail.smtp.password`                              | SMTP password                                                                                       | `''`                       |
+| `nextcloud.configs`                                         | Config files created in `/var/www/html/config`                                                      | `{}`                       |
+| `nextcloud.persistence.subPath`                             | Set the subPath for nextcloud to use in volume                                                      | `nil`                      |
+| `nextcloud.phpConfigs`                                      | PHP Config files created in `/usr/local/etc/php/conf.d`                                             | `{}`                       |
+| `nextcloud.defaultConfigs.\.htaccess`                       | Default .htaccess to protect `/var/www/html/config`                                                 | `true`                     |
+| `nextcloud.defaultConfigs.apache-pretty-urls\.config\.php`  | Default Apache configuration for rewrite urls                                                       | `true`                     |
+| `nextcloud.defaultConfigs.apcu\.config\.php`                | Default configuration to define APCu as local cache                                                 | `true`                     |
+| `nextcloud.defaultConfigs.apps\.config\.php`                | Default configuration for apps                                                                      | `true`                     |
+| `nextcloud.defaultConfigs.autoconfig\.php`                  | Default auto-configuration for databases                                                            | `true`                     |
+| `nextcloud.defaultConfigs.redis\.config\.php`               | Default Redis configuration                                                                         | `true`                     |
+| `nextcloud.defaultConfigs.reverse-proxy\.config\.php`       | Default Reverse proxy configuration                                                                 | `true`                     |
+| `nextcloud.defaultConfigs.s3\.config\.php`                  | Default configuration for S3 as primary Object Storage                                              | `true`                     |
+| `nextcloud.defaultConfigs.smtp\.config\.php`                | Default configuration for smtp                                                                      | `true`                     |
+| `nextcloud.defaultConfigs.swift\.config\.php`               | Default configuration for Swift as primary Object Storage                                           | `true`                     |
+| `nextcloud.defaultConfigs.upgrade-disable-web\.config\.php` | Default config to disable the web-based updater as the default docker image does not suppor it      | `true`                     |
+| `nextcloud.strategy`                                        | specifies the strategy used to replace old Pods by new ones                                         | `type: Recreate`           |
+| `nextcloud.extraEnv`                                        | specify additional environment variables                                                            | `{}`                       |
+| `nextcloud.extraSidecarContainers`                          | specify additional sidecar containers                                                               | `[]`                       |
+| `nextcloud.extraInitContainers`                             | specify additional init containers                                                                  | `[]`                       |
+| `nextcloud.extraVolumes`                                    | specify additional volumes for the NextCloud pod                                                    | `{}`                       |
+| `nextcloud.extraVolumeMounts`                               | specify additional volume mounts for the NextCloud pod                                              | `{}`                       |
+| `nextcloud.securityContext`                                 | Optional security context for the NextCloud container                                               | `nil`                      |
+| `nextcloud.podSecurityContext`                              | Optional security context for the NextCloud pod (applies to all containers in the pod)              | `nil`                      |
+| `nginx.enabled`                                             | Enable nginx (requires you use php-fpm image)                                                       | `false`                    |
+| `nginx.image.repository`                                    | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container                     | `nginx`                    |
+| `nginx.image.tag`                                           | nginx Image tag                                                                                     | `alpine`                   |
+| `nginx.image.pullPolicy`                                    | nginx Image pull policy                                                                             | `IfNotPresent`             |
+| `nginx.image.pullPolicy`                                    | nginx Image pull policy                                                                             | `IfNotPresent`             |
+| `nginx.containerPort`                                       | Customize container port e.g. when not running as root                                              | `IfNotPresent`             |
+| `nginx.config.default`                                      | Whether to use nextcloud's recommended nginx config                                                 | `true`                     |
+| `nginx.config.custom`                                       | Specify a custom config for nginx                                                                   | `{}`                       |
+| `nginx.resources`                                           | nginx resources                                                                                     | `{}`                       |
+| `nginx.securityContext`                                     | Optional security context for the nginx container                                                   | `nil`                      |
+| `nginx.extraEnv`                                            | Optional environment variables for the nginx container                                              | `nil`                      |
+| `lifecycle.postStartCommand`                                | Specify deployment lifecycle hook postStartCommand                                                  | `nil`                      |
+| `lifecycle.preStopCommand`                                  | Specify deployment lifecycle hook preStopCommand                                                    | `nil`                      |
+| `redis.enabled`                                             | Whether to install/use redis for locking                                                            | `false`                    |
+| `redis.auth.enabled`                                        | Whether to enable password authentication with redis                                                | `true`                     |
+| `redis.auth.password`                                       | The password redis uses                                                                             | `''`                       |
+| `redis.auth.existingSecret`                                 | The name of an existing secret with Redis® credentials                                              | `''`                       |
+| `redis.auth.existingSecretPasswordKey`                      | Password key to be retrieved from existing secret                                                   | `''`                       |
+| `redis.global.storageClass`                                 | PVC Storage Class  for both Redis&reg; master and replica Persistent Volumes                        | `''`                       |
+| `redis.master.persistence.enabled`                          | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                        | `true`                     |
+| `redis.replica.persistence.enabled`                         | Enable persistence on Redis&reg; replica nodes using Persistent Volume Claims                       | `true`                     |
+| `cronjob.enabled`                                           | Whether to enable/disable cron jobs sidecar                                                         | `false`                    |
+| `cronjob.lifecycle.postStartCommand`                        | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                        | `nil`                      |
+| `cronjob.lifecycle.preStopCommand`                          | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                          | `nil`                      |
+| `cronjob.resources`                                         | CPU/Memory resource requests/limits for the cron jobs sidecar                                       | `{}`                       |
+| `cronjob.securityContext`                                   | Optional security context for cron jobs sidecar                                                     | `nil`                      |
+| `service.type`                                              | Kubernetes Service type                                                                             | `ClusterIP`                |
+| `service.loadBalancerIP`                                    | LoadBalancerIp for service type LoadBalancer                                                        | `""`                       |
+| `service.annotations`                                       | Annotations for service type                                                                        | `{}`                       |
+| `service.nodePort`                                          | NodePort for service type NodePort                                                                  | `nil`                      |
+| `service.ipFamilies`                                        | Set ipFamilies as in k8s service objects                                                            | `nil`                      |
+| `service.ipFamyPolicy`                                      | define IP protocol bindings as in k8s service objects                                               | `nil`                      |
+| `phpClientHttpsFix.enabled`                                 | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `false`                    |
+| `phpClientHttpsFix.protocol`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `https`                    |
+| `resources`                                                 | CPU/Memory resource requests/limits                                                                 | `{}`                       |
+| `rbac.enabled`                                              | Enable Role and rolebinding for priveledged PSP                                                     | `false`                    |
+| `rbac.serviceaccount.create`                                | Wether to create a serviceaccount or use an existing one (requires rbac)                            | `true`                     |
+| `rbac.serviceaccount.name`                                  | The name of the sevice account that the deployment will use (requires rbac)                         | `nextcloud-serviceaccount` |
+| `rbac.serviceaccount.annotations`                           | Serviceaccount annotations                                                                          | `{}`                       |
+| `livenessProbe.enabled`                                     | Turn on and off liveness probe                                                                      | `true`                     |
+| `livenessProbe.initialDelaySeconds`                         | Delay before liveness probe is initiated                                                            | `10`                       |
+| `livenessProbe.periodSeconds`                               | How often to perform the probe                                                                      | `10`                       |
+| `livenessProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
+| `livenessProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `3`                        |
+| `livenessProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
+| `readinessProbe.enabled`                                    | Turn on and off readiness probe                                                                     | `true`                     |
+| `readinessProbe.initialDelaySeconds`                        | Delay before readiness probe is initiated                                                           | `10`                       |
+| `readinessProbe.periodSeconds`                              | How often to perform the probe                                                                      | `10`                       |
+| `readinessProbe.timeoutSeconds`                             | When the probe times out                                                                            | `5`                        |
+| `readinessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                                          | `3`                        |
+| `readinessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                                         | `1`                        |
+| `startupProbe.enabled`                                      | Turn on and off startup probe                                                                       | `false`                    |
+| `startupProbe.initialDelaySeconds`                          | Delay before readiness probe is initiated                                                           | `30`                       |
+| `startupProbe.periodSeconds`                                | How often to perform the probe                                                                      | `10`                       |
+| `startupProbe.timeoutSeconds`                               | When the probe times out                                                                            | `5`                        |
+| `startupProbe.failureThreshold`                             | Minimum consecutive failures for the probe                                                          | `30`                       |
+| `startupProbe.successThreshold`                             | Minimum consecutive successes for the probe                                                         | `1`                        |
+| `hpa.enabled`                                               | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
+| `hpa.cputhreshold`                                          | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
+| `hpa.minPods`                                               | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
+| `hpa.maxPods`                                               | Max. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `10`                       |
+| `deploymentLabels`                                          | Labels to be added at 'deployment' level                                                            | not set                    |
+| `deploymentAnnotations`                                     | Annotations to be added at 'deployment' level                                                       | not set                    |
+| `podLabels`                                                 | Labels to be added at 'pod' level                                                                   | not set                    |
+| `podAnnotations`                                            | Annotations to be added at 'pod' level                                                              | not set                    |
+| `dnsConfig`                                                 | Custom dnsConfig for nextcloud containers                                                           | `{}`                       |
 
 ### Database Configurations
 By default, nextcloud will use a SQLite database. This is not recommended for production, but is enabled by default for testing purposes. When you are done testing, please set `internalDatabase.enabled` to `false`, and configure the `externalDatabase` parameters below.
@@ -266,6 +271,53 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `postgresql.primary.persistence.existingClaim`                        | Use an existing PVC for PostgreSQL primary                                        | `nil`                  |
 
 Is there a missing parameter for one of the Bitnami helm charts listed above? Please feel free to submit a PR to add that parameter in our values.yaml, but be sure to also update this README file :)
+
+
+### Object Storage as Primary Storage Configuration
+
+Nextcloud allows to configure object storages like OpenStack Swift or Amazon Simple Storage Service (S3) or any compatible S3-implementation (e.g. Minio or Ceph Object Gateway) as primary storage replacing the default storage of files.
+
+By default, files are stored in nextcloud/data or another directory configured in the config.php of your Nextcloud instance. This data directory might still be used for compatibility reasons)
+
+Read more in the official [docs](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#configuring-object-storage-as-primary-storage).
+
+Here are all the values you can currently configure in this helm chart to configure an Object Store as your Primary Storage.
+
+
+| Parameter                                       | Description                                                           | Default     |
+|-------------------------------------------------|-----------------------------------------------------------------------|-------------|
+| `nextcloud.objectStore.s3.enabled`              | enable configuring S3 as a primary object store                       | `false`     |
+| `nextcloud.objectStore.s3.accessKey`            | accessKeyID for authing to S3, ignored if using existinSecret         | `''`        |
+| `nextcloud.objectStore.s3.secretKey`            | secretAccessKey for authing to S3, ignored if using existinSecret     | `''`        |
+| `nextcloud.objectStore.s3.legacyAuth`           | use legacy authentication for S3                                      | `false`     |
+| `nextcloud.objectStore.s3.host`                 | endpoint URL to connect to. Only required if not using AWS            | `''`        |
+| `nextcloud.objectStore.s3.ssl`                  | Use TLS connection when connecting to S3                              | `true`      |
+| `nextcloud.objectStore.s3.port`                 | Port for S3 host to use                                               | `443`       |
+| `nextcloud.objectStore.s3.region`               | region to look for bucket in on the S3 host                           | `eu-west-1` |
+| `nextcloud.objectStore.s3.bucket`               | bucket on the S3 host                                                 | `''`        |
+| `nextcloud.objectStore.s3.prefix`               | optional object prefix                                                | `''`        |
+| `nextcloud.objectStore.s3.usePathStyle`         | set to true if you are not using DNS for your buckets                 | `false`     |
+| `nextcloud.objectStore.s3.autoCreate`           | auto-create the S3 bucket                                             | `false`     |
+| `nextcloud.objectStore.s3.storageClass`         | S3 storage class to use                                               | `STANDARD`  |
+| `nextcloud.objectStore.s3.sse_c_key`            | S3 server side encryption key.                                        | `''`        |
+| `nextcloud.objectStore.s3.existingSecret`       | Use an existing Kubernetes Secret to fetch auth credentials           | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.host`      | if using s3.existingSecret, secret key to use for the host            | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.accessKey` | if using s3.existingSecret, secret key to use for the accessKeyID     | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.secretKey` | if using s3.existingSecret, secret key to use for the secretAccessKey | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.bucket`    | if using s3.existingSecret, secret key to use for the bucket          | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.sse_c_key` | if using s3.existingSecret, secret key to use for the sse_c_key       | `''`        |
+| `nextcloud.objectStore.swift.enabled`           | enable configuring Openstack Swift as a primary object store          | `false`     |
+| `nextcloud.objectStore.swift.user.domain`       | optional: swift user domain                                           | `'Default'` |
+| `nextcloud.objectStore.swift.user.name`         | Swift username                                                        | `''`        |
+| `nextcloud.objectStore.swift.user.password`     | Swift user password                                                   | `''`        |
+| `nextcloud.objectStore.swift.project.name`      | Swift project name                                                    | `''`        |
+| `nextcloud.objectStore.swift.project.domain`    | optional: swift project domain                                        | `'Default'` |
+| `nextcloud.objectStore.swift.url`               | Swift Identity / Keystone endpoint                                    | `''`        |
+| `nextcloud.objectStore.swift.region`            | Swift region                                                          | `''`        |
+| `nextcloud.objectStore.swift.service`           | Optional: service name, used on some swift implementations            | `'swift'`   |
+| `nextcloud.objectStore.swift.container`         | Swift container to store the data in                                  | `''`        |
+| `nextcloud.objectStore.swift.autoCreate`        | Autocreate the Swift container                                        | `false`     |
+
 
 
 ### Persistence Configurations
@@ -363,31 +415,39 @@ To execute [background tasks](https://docs.nextcloud.com/server/latest/admin_man
 
 Enabling this option will create a sidecar container in the Nextcloud pod, which will start a [`crond` daemon](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) responsible for running the Nextcloud cron.php script. At first launch, the background jobs mode in your Nextcloud basic settings will automatically be set to ***Cron***.
 
+
+## Using the nextcloud docker image auto-configuration via env vars
+
+The [nextcloud/docker](https://github.com/nextcloud/docker/tree/master) image provides an auto-configuration via environment variables. See [their docs](https://github.com/nextcloud/docker/tree/master#auto-configuration-via-environment-variables) for more info.
+
+
 ## Multiple config.php file
 
 Nextcloud supports loading configuration parameters from multiple files.
 You can add arbitrary files ending with `.config.php` in the `config/` directory.
-See [documentation](https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file).
+See [documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file). For example, to enable image and document previews:
 
-For example, following config will configure Nextcloud with [S3 as primary storage](https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) by creating file `/var/www/html/config/s3.config.php`:
 
 ```yaml
 nextcloud:
   configs:
-    s3.config.php: |-
+    previews.config.php: |-
       <?php
       $CONFIG = array (
-        'objectstore' => array(
-          'class' => '\\OC\\Files\\ObjectStore\\S3',
-          'arguments' => array(
-            'bucket'     => 'my-bucket',
-            'autocreate' => true,
-            'key'        => 'xxx',
-            'secret'     => 'xxx',
-            'region'     => 'us-east-1',
-            'use_ssl'    => true
-          )
-        )
+        'enable_previews' => true,
+        'enabledPreviewProviders' => array (
+          'OC\Preview\Movie',
+          'OC\Preview\PNG',
+          'OC\Preview\JPEG',
+          'OC\Preview\GIF',
+          'OC\Preview\BMP',
+          'OC\Preview\XBitmap',
+          'OC\Preview\MP3',
+          'OC\Preview\MP4',
+          'OC\Preview\TXT',
+          'OC\Preview\MarkDown',
+          'OC\Preview\PDF'
+        ),
       );
 ```
 

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -120,6 +120,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.existingSecret.smtpHostKey`                      | Name of the key that contains the SMTP hostname                                                     | `nil`                      |
 | `nextcloud.update`                                          | Trigger update if custom command is used                                                            | `0`                        |
 | `nextcloud.containerPort`                                   | Customize container port when not running as root                                                   | `80`                       |
+| `nextcloud.trustedDomains`                                  | Optional space-separated list of trusted domains                                                    | `[]`                       |
 | `nextcloud.datadir`                                         | nextcloud data dir location                                                                         | `/var/www/html/data`       |
 | `nextcloud.mail.enabled`                                    | Whether to enable/disable email settings                                                            | `false`                    |
 | `nextcloud.mail.fromAddress`                                | nextcloud mail send from field                                                                      | `nil`                      |

--- a/charts/nextcloud/files/defaultConfigs/autoconfig.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/autoconfig.php.tpl
@@ -4,12 +4,26 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG["dbtype"] = "sqlite";
     $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
     $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'mysql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
+    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
 } elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
     $AUTOCONFIG["dbtype"] = "mysql";
     $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
     $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
     $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
     $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'pgsql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
+    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
     $autoconfig_enabled = true;
 } elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG["dbtype"] = "pgsql";

--- a/charts/nextcloud/files/defaultConfigs/redis.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/redis.config.php.tpl
@@ -1,14 +1,17 @@
 <?php
 if (getenv('REDIS_HOST')) {
-  $CONFIG = array (
+  $CONFIG = array(
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
       'host' => getenv('REDIS_HOST'),
-      'port' => getenv('REDIS_HOST_PORT') ?: 6379,
-      {{- if .Values.redis.auth.enabled }}
-      'password' => getenv('REDIS_HOST_PASSWORD'),
-      {{- end }}
+      'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
 }

--- a/charts/nextcloud/files/defaultConfigs/reverse-proxy.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/reverse-proxy.config.php.tpl
@@ -1,0 +1,30 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
@@ -1,0 +1,48 @@
+<?php
+if (getenv('OBJECTSTORE_S3_BUCKET')) {
+  $use_ssl = getenv('OBJECTSTORE_S3_SSL');
+  $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
+  $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
+  $CONFIG = array(
+    'objectstore' => array(
+      'class' => '\OC\Files\ObjectStore\S3',
+      'arguments' => array(
+        'bucket' => getenv('OBJECTSTORE_S3_BUCKET'),
+        'region' => getenv('OBJECTSTORE_S3_REGION') ?: '',
+        'hostname' => getenv('OBJECTSTORE_S3_HOST') ?: '',
+        'port' => getenv('OBJECTSTORE_S3_PORT') ?: '',
+        'storageClass' => getenv('OBJECTSTORE_S3_STORAGE_CLASS') ?: '',
+        'objectPrefix' => getenv("OBJECTSTORE_S3_OBJECT_PREFIX") ? getenv("OBJECTSTORE_S3_OBJECT_PREFIX") : "urn:oid:",
+        'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
+        'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
+        // required for some non Amazon S3 implementations
+        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
+      )
+    )
+  );
+
+  if (getenv('OBJECTSTORE_S3_KEY_FILE')) {
+    $CONFIG['objectstore']['arguments']['key'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_KEY_FILE')));
+  } elseif (getenv('OBJECTSTORE_S3_KEY')) {
+    $CONFIG['objectstore']['arguments']['key'] = getenv('OBJECTSTORE_S3_KEY');
+  } else {
+    $CONFIG['objectstore']['arguments']['key'] = '';
+  }
+
+  if (getenv('OBJECTSTORE_S3_SECRET_FILE')) {
+    $CONFIG['objectstore']['arguments']['secret'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_SECRET_FILE')));
+  } elseif (getenv('OBJECTSTORE_S3_SECRET')) {
+    $CONFIG['objectstore']['arguments']['secret'] = getenv('OBJECTSTORE_S3_SECRET');
+  } else {
+    $CONFIG['objectstore']['arguments']['secret'] = '';
+  }
+
+  if (getenv('OBJECTSTORE_S3_SSE_C_KEY_FILE')) {
+    $CONFIG['objectstore']['arguments']['sse_c_key'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_SSE_C_KEY_FILE')));
+  } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
+    $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
+  }
+}

--- a/charts/nextcloud/files/defaultConfigs/smtp.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/smtp.config.php.tpl
@@ -5,11 +5,18 @@ if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN'))
     'mail_smtphost' => getenv('SMTP_HOST'),
     'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
     'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
-    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauth' => getenv('SMTP_NAME') && (getenv('SMTP_PASSWORD') || getenv('SMTP_PASSWORD_FILE')),
     'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
     'mail_smtpname' => getenv('SMTP_NAME') ?: '',
-    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
     'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
     'mail_domain' => getenv('MAIL_DOMAIN'),
   );
+
+  if (getenv('SMTP_PASSWORD_FILE')) {
+      $CONFIG['mail_smtppassword'] = trim(file_get_contents(getenv('SMTP_PASSWORD_FILE')));
+  } elseif (getenv('SMTP_PASSWORD')) {
+      $CONFIG['mail_smtppassword'] = getenv('SMTP_PASSWORD');
+  } else {
+      $CONFIG['mail_smtppassword'] = '';
+  }
 }

--- a/charts/nextcloud/files/defaultConfigs/swift.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/swift.config.php.tpl
@@ -1,0 +1,31 @@
+<?php
+if (getenv('OBJECTSTORE_SWIFT_URL')) {
+    $autocreate = getenv('OBJECTSTORE_SWIFT_AUTOCREATE');
+  $CONFIG = array(
+    'objectstore' => [
+      'class' => 'OC\\Files\\ObjectStore\\Swift',
+      'arguments' => [
+        'autocreate' => $autocreate == true && strtolower($autocreate) !== 'false',
+        'user' => [
+          'name' => getenv('OBJECTSTORE_SWIFT_USER_NAME'),
+          'password' => getenv('OBJECTSTORE_SWIFT_USER_PASSWORD'),
+          'domain' => [
+            'name' => (getenv('OBJECTSTORE_SWIFT_USER_DOMAIN')) ?: 'Default',
+          ],
+        ],
+        'scope' => [
+          'project' => [
+            'name' => getenv('OBJECTSTORE_SWIFT_PROJECT_NAME'),
+            'domain' => [
+              'name' => (getenv('OBJECTSTORE_SWIFT_PROJECT_DOMAIN')) ?: 'Default',
+            ],
+          ],
+        ],
+        'serviceName' => (getenv('OBJECTSTORE_SWIFT_SERVICE_NAME')) ?: 'swift',
+        'region' => getenv('OBJECTSTORE_SWIFT_REGION'),
+        'url' => getenv('OBJECTSTORE_SWIFT_URL'),
+        'bucket' => getenv('OBJECTSTORE_SWIFT_CONTAINER_NAME'),
+      ]
+    ]
+  );
+}

--- a/charts/nextcloud/files/defaultConfigs/upgrade-disable-web.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/upgrade-disable-web.config.php.tpl
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'upgrade.disable-web' => true,
+);

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -178,7 +178,11 @@ Create environment variables used to configure the nextcloud container as well a
       name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
       key: {{ .Values.nextcloud.existingSecret.passwordKey }}
 - name: NEXTCLOUD_TRUSTED_DOMAINS
+  {{- if .Values.nextcloud.trustedDomains }}
+  value: {{ join " " .Values.nextcloud.trustedDomains | quote }}
+  {{- else }}
   value: {{ .Values.nextcloud.host }}{{ if .Values.metrics.enabled }} {{ template "nextcloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+  {{- end }}
 {{- if ne (int .Values.nextcloud.update) 0 }}
 - name: NEXTCLOUD_UPDATE
   value: {{ .Values.nextcloud.update | quote }}

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -212,6 +212,9 @@ Create environment variables used to configure the nextcloud container as well a
       name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
       key: {{ .Values.nextcloud.existingSecret.smtpPasswordKey }}
 {{- end }}
+{{/*
+Redis env vars
+*/}}
 {{- if .Values.redis.enabled }}
 - name: REDIS_HOST
   value: {{ template "nextcloud.redis.fullname" . }}-master
@@ -229,7 +232,107 @@ Create environment variables used to configure the nextcloud container as well a
   value: {{ .Values.redis.auth.password }}
 {{- end }}
 {{- end }}
+{{- end }}{{/* end if redis.enabled */}}
+{{/*
+S3 as primary object store env vars
+*/}}
+{{- if .Values.nextcloud.objectStore.s3.enabled }}
+- name: OBJECTSTORE_S3_SSL
+  value: {{ .Values.nextcloud.objectStore.s3.ssl | quote }}
+- name: OBJECTSTORE_S3_USEPATH_STYLE
+  value: {{ .Values.nextcloud.objectStore.s3.usePathStyle | quote }}
+{{- with .Values.nextcloud.objectStore.s3.legacyAuth }}
+- name: OBJECTSTORE_S3_LEGACYAUTH
+  value: {{ . }}
 {{- end }}
+- name: OBJECTSTORE_S3_AUTOCREATE
+  value: {{ .Values.nextcloud.objectStore.s3.autoCreate | quote }}
+- name: OBJECTSTORE_S3_REGION
+  value: {{ .Values.nextcloud.objectStore.s3.region | quote }}
+- name: OBJECTSTORE_S3_PORT
+  value: {{ .Values.nextcloud.objectStore.s3.port | quote }}
+- name: OBJECTSTORE_S3_STORAGE_CLASS
+  value: {{ .Values.nextcloud.objectStore.s3.storageClass | quote }}
+{{- with .Values.nextcloud.objectStore.s3.prefix }}
+- name: OBJECTSTORE_S3_OBJECT_PREFIX
+  value: {{ . | quote }}
+{{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.host }}
+- name: OBJECTSTORE_S3_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.host }}
+{{- else }}
+- name: OBJECTSTORE_S3_HOST
+  value: {{ .Values.nextcloud.objectStore.s3.host | quote }}
+{{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.bucket }}
+- name: OBJECTSTORE_S3_BUCKET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.bucket }}
+{{- else }}
+- name: OBJECTSTORE_S3_BUCKET
+  value: {{ .Values.nextcloud.objectStore.s3.bucket | quote }}
+{{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.accessKey }}
+- name: OBJECTSTORE_S3_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.accessKey }}
+{{- else }}
+- name: OBJECTSTORE_S3_KEY
+  value: {{ .Values.nextcloud.objectStore.s3.accessKey | quote }}
+{{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.secretKey }}
+- name: OBJECTSTORE_S3_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.secretKey }}
+{{- else }}
+- name: OBJECTSTORE_S3_SECRET
+  value: {{ .Values.nextcloud.objectStore.s3.secretKey | quote }}
+{{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.bucket }}
+- name: OBJECTSTORE_S3_SSE_C_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.sse_c_key }}
+{{- else }}
+- name: OBJECTSTORE_S3_SSE_C_KEY
+  value: {{ .Values.nextcloud.objectStore.s3.sse_c_key | quote }}
+{{- end }}
+{{- end }}{{/* end if nextcloud.objectStore.s3.enabled */}}
+{{/*
+Swift as primary object store env vars
+*/}}
+{{- if .Values.nextcloud.objectStore.swift.enabled }}
+- name: OBJECTSTORE_SWIFT_AUTOCREATE
+  value: {{ .Values.nextcloud.objectStore.swift.autoCreate | quote }}
+- name: OBJECTSTORE_SWIFT_USER_NAME
+  value: {{ .Values.nextcloud.objectStore.swift.user.name | quote }}
+- name: OBJECTSTORE_SWIFT_USER_PASSWORD
+  value: {{ .Values.nextcloud.objectStore.swift.user.password | quote }}
+- name: OBJECTSTORE_SWIFT_USER_DOMAIN
+  value: {{ .Values.nextcloud.objectStore.swift.user.domain | quote }}
+- name: OBJECTSTORE_SWIFT_PROJECT_NAME
+  value: {{ .Values.nextcloud.objectStore.swift.project.name | quote }}
+- name: OBJECTSTORE_SWIFT_PROJECT_DOMAIN
+  value: {{ .Values.nextcloud.objectStore.swift.project.domain | quote }}
+- name: OBJECTSTORE_SWIFT_SERVICE_NAME
+  value: {{ .Values.nextcloud.objectStore.swift.service | quote }}
+- name: OBJECTSTORE_SWIFT_REGION
+  value: {{ .Values.nextcloud.objectStore.swift.region | quote }}
+- name: OBJECTSTORE_SWIFT_URL
+  value: {{ .Values.nextcloud.objectStore.swift.url | quote }}
+- name: OBJECTSTORE_SWIFT_CONTAINER_NAME
+  value: {{ .Values.nextcloud.objectStore.swift.container | quote }}
+{{- end }}{{/* end if nextcloud.objectStore.s3.enabled */}}
 {{- if .Values.nextcloud.extraEnv }}
 {{ toYaml .Values.nextcloud.extraEnv }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -93,9 +93,12 @@ nextcloud:
   datadir: /var/www/html/data
   persistence:
     subPath:
+  ## SMTP configuration
   mail:
     enabled: false
+    # the user we send email as
     fromAddress: user
+    # the domain we send email from
     domain: domain.com
     smtp:
       host: domain.com
@@ -104,17 +107,85 @@ nextcloud:
       authtype: LOGIN
       name: user
       password: pass
-  # PHP Configuration files
+  ## Primary ObjectStore options
+  # see: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#configuring-object-storage-as-primary-storage
+  objectStore:
+    # https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3
+    s3:
+      enabled: false
+      # ignored if nextcloud.objectstore.s3.existingSecret is not empty string
+      accessKey: ""
+      # ignored if nextcloud.objectstore.s3.existingSecret is not empty string
+      secretKey: ""
+      # use legacy auth method
+      legacyAuth: false
+      # s3 endpoint to use; only required if you're not using AWS
+      host: ""
+      # use TLS/SSL for S3 connections
+      ssl: true
+      # default port that can be changed based on your object store, e.g. for minio, you can use 9000
+      port: "443"
+      # this is the default in the nextcloud docs
+      region: "eu-west-1"
+      # required if using s3, the name of the bucket you'd like to use
+      bucket: ""
+      # object prefix in bucket
+      prefix: ""
+      # set to true if you are not using DNS for your buckets.
+      usePathStyle: false
+      # autocreate the bucket
+      autoCreate: false
+      # optonal parameter: you probably want to keep this as default
+      storageClass: "STANDARD"
+      # server side encryption key. learn more: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#s3-sse-c-encryption-support
+      sse_c_key: ""
+      # use an existingSecret for S3 credentials. If set, we ignore the following under nextcloud.objectStore.s3
+      # endpoint, accessKey, secretKey
+      existingSecret: ""
+      secretKeys:
+        # key in nextcloud.objectStore.s3.existingSecret to use for s3 endpoint
+        host: ""
+        # key in nextcloud.objectStore.s3.existingSecret to use for s3 accessKeyID
+        accessKey: ""
+        # key in nextcloud.objectStore.s3.existingSecret to use for s3 secretAccessKey
+        secretKey: ""
+        # key in nextcloud.objectStore.s3.existingSecret to use for the s3 bucket
+        bucket: ""
+        # key in nextcloud.objectStore.s3.existingSecret to use for the s3 sse_c_key
+        sse_c_key: ""
+    ## options related to using Swift as a primary object storage
+    # https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#openstack-swift
+    swift:
+      enabled: false
+      # swift user info
+      user:
+        domain: "Default"
+        name: ""
+        password: ""
+      # swift project info
+      project:
+        name: ""
+        domain: "Default"
+      # The Identity / Keystone endpoint
+      url: ""
+      region: ""
+      # optional on some swift implementations
+      service: "swift"
+      # the container to store the data in
+      container: ""
+      # autocreate container
+      autoCreate: false
+
+  ## PHP Configuration files
   # Will be injected in /usr/local/etc/php/conf.d for apache image and in /usr/local/etc/php-fpm.d when nginx.enabled: true
   phpConfigs: {}
-  # Default config files
+  ## Default config files that utilize environment variables:
+  # see: https://github.com/nextcloud/docker/tree/master#auto-configuration-via-environment-variables
   # IMPORTANT: Will be used only if you put extra configs, otherwise default will come from nextcloud itself
-  # Default confgurations can be found here: https://github.com/nextcloud/docker/tree/master/16.0/apache/config
+  # Default confgurations can be found here: https://github.com/nextcloud/docker/tree/master/.config
   defaultConfigs:
     # To protect /var/www/html/config
     .htaccess: true
-    # Redis default configuration
-    redis.config.php: true
     # Apache configuration for rewrite urls
     apache-pretty-urls.config.php: true
     # Define APCu as local cache
@@ -123,31 +194,41 @@ nextcloud:
     apps.config.php: true
     # Used for auto configure database
     autoconfig.php: true
-    # SMTP default configuration
+    # Redis default configuration
+    redis.config.php: true
+    # Reverse proxy default configuration
+    reverse-proxy.config.php: true
+    # S3 Object Storage as primary storage
+    s3.config.php: true
+    # SMTP default configuration via environment variables
     smtp.config.php: true
-  # Extra config files created in /var/www/html/config/
-  # ref: https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
-  configs: {}
+    # Swift Object Storage as primary storage
+    swift.config.php: true
+    # disables the web based updater as the default nextcloud docker image does not support it
+    upgrade-disable-web.config.php: true
 
-  # For example, to use S3 as primary storage
-  # ref: https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3
-  #
-  #  configs:
-  #    s3.config.php: |-
-  #      <?php
-  #      $CONFIG = array (
-  #        'objectstore' => array(
-  #          'class' => '\\OC\\Files\\ObjectStore\\S3',
-  #          'arguments' => array(
-  #            'bucket'     => 'my-bucket',
-  #            'autocreate' => true,
-  #            'key'        => 'xxx',
-  #            'secret'     => 'xxx',
-  #            'region'     => 'us-east-1',
-  #            'use_ssl'    => true
-  #          )
-  #        )
-  #      );
+  # Extra config files created in /var/www/html/config/
+  # ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
+  configs: {}
+  # For example, to enable image and text file previews:
+  #  previews.config.php: |-
+  #    <?php
+  #    $CONFIG = array (
+  #      'enable_previews' => true,
+  #      'enabledPreviewProviders' => array (
+  #        'OC\Preview\Movie',
+  #        'OC\Preview\PNG',
+  #        'OC\Preview\JPEG',
+  #        'OC\Preview\GIF',
+  #        'OC\Preview\BMP',
+  #        'OC\Preview\XBitmap',
+  #        'OC\Preview\MP3',
+  #        'OC\Preview\MP4',
+  #        'OC\Preview\TXT',
+  #        'OC\Preview\MarkDown',
+  #        'OC\Preview\PDF'
+  #      ),
+  #    );
 
   # Hooks for auto configuration
   # Here you could write small scripts which are placed in `/docker-entrypoint-hooks.d/<hook-name>/helm.sh`

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -93,6 +93,8 @@ nextcloud:
   datadir: /var/www/html/data
   persistence:
     subPath:
+  # if set, we'll template this list to the NEXTCLOUD_TRUSTED_DOMAINS env var
+  trustedDomains: []
   ## SMTP configuration
   mail:
     enabled: false


### PR DESCRIPTION
## Description of the change

- Updates the following files to match the upstream [`nextcloud/docker` config files](https://github.com/nextcloud/docker/tree/2accbecd979916d0c0f63fcb97d87f4970616db9/.config):
  - `charts/nextcloud/files/defaultConfigs/autoconfig.php.tpl`
  - `charts/nextcloud/files/defaultConfigs/redis.config.php.tpl`
  - `charts/nextcloud/files/defaultConfigs/reverse-proxy.config.php.tpl` 🆕 
  - `charts/nextcloud/files/defaultConfigs/s3.config.php.tpl` 🆕 
  - `charts/nextcloud/files/defaultConfigs/smtp.config.php.tpl`
  - `charts/nextcloud/files/defaultConfigs/swift.config.php.tpl` 🆕 
  - `charts/nextcloud/files/defaultConfigs/upgrade-disable-web.config.php.tpl` 🆕 
  
- Adds `nextcloud.objectStore.s3` to use [S3 for primary storage](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#configuring-object-storage-as-primary-storage):
  <details>
    <summary>click me for new <code>nextcloud.objectStore.s3</code> values</summary>
    
  ```yaml
  nextcloud:
    objectStore:
      s3:
        enabled: false
        # ignored if nextcloud.objectstore.s3.existingSecret is not empty string
        accessKey: ""
        # ignored if nextcloud.objectstore.s3.existingSecret is not empty string
        secretKey: ""
        # use legacy auth method
        legacyAuth: false
        # s3 endpoint to use; only required if you're not using AWS
        host: ""
        # use TLS/SSL for S3 connections
        ssl: true
        # default port that can be changed based on your object store, e.g. for minio, you can use 9000
        port: "443"
        # this is the default in the nextcloud docs
        region: "eu-west-1"
  provokateurin marked this conversation as resolved.
        # required if using s3, the name of the bucket you'd like to use
        bucket: ""
        # object prefix in bucket
        prefix: ""
        # set to true if you are not using DNS for your buckets.
        usePathStyle: false
        # autocreate the bucket
        autoCreate: false
        # optonal parameter: you probably want to keep this as default
        storageClass: "STANDARD"
        # server side encryption key. learn more: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#s3-sse-c-encryption-support
        sse_c_key: ""
        # use an existingSecret for S3 credentials. If set, we ignore the following under nextcloud.objectStore.s3
        # endpoint, accessKey, secretKey
        existingSecret: ""
        secretKeys:
          # key in nextcloud.objectStore.s3.existingSecret to use for s3 endpoint
          host: ""
          # key in nextcloud.objectStore.s3.existingSecret to use for s3 accessKeyID
          accessKey: ""
          # key in nextcloud.objectStore.s3.existingSecret to use for s3 secretAccessKey
          secretKey: ""
          # key in nextcloud.objectStore.s3.existingSecret to use for the s3 bucket
          bucket: ""
          # key in nextcloud.objectStore.s3.existingSecret to use for the s3 sse_c_key
          sse_c_key: ""
  ```
  
  </details>
  
- Adds `nextcloud.objectStore.swift` to use [OpenStack Swift for primary storage](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#openstack-swift):
  <details>
    <summary>click me for new <code>nextcloud.objectStore.swift</code> values</summary>
    
  ```yaml
  nextcloud:
    objectStore:
      ## options related to using Swift as a primary object storage 
      swift:
        enabled: false
        # swift user info
        user:
          domain: "Default"
          name: ""
          password: ""
        # swift project info
        project:
          name: ""
          domain: "Default"
        # The Identity / Keystone endpoint
        url: ""
        region: ""
        # optional on some swift implementations
        service: "swift"
        # the container to store the data in
        container: ""
        # autocreate container
        autoCreate: false
  ```
  
  </details>
  
- adds a new ci `test_case` for enabling S3 as a primary object store
  - includes installing MinIO conditionally using the [community MinIO helm chart](https://github.com/minio/minio/tree/master/helm/minio)
  - includes a k8s test job to upload a file conditionally
  
- adds `nextcloud.trustedDomains` as a helm parameter. Takes a list that, if set, we then template out to a space separated list. Otherwise, we still use our default templating for that parameter (which uses `nextcloud.host`)

- rename `run-tests` job to `test` since the job before it is just called `lint` and it keeps the check names from truncating as much in the following view (can't be longer than 30 characters):
  <img width="1142" alt="Screenshot of the nextcloud/helm github actions workflow summary showing the names of each matrix strategy test case jobs being truncated to 30 characters" src="https://github.com/user-attachments/assets/3bbfbf47-dfc2-446b-aecf-9169373b2577">

## Benefits

This lets users use both `nextcloud.configs` _and_ still use the [nextcloud/docker auto configuration via environment variables](https://github.com/nextcloud/docker/tree/master#auto-configuration-via-environment-variables). Prior to this change, you had to use one or the other when it came to s3 as primary object storage.

## Possible drawbacks

not sure 🤷 but always open to feedback :)

## Applicable issues
- fixes #477 
- fixes #69
- fixes #41
- fixes #425

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
