### PR TITLE
Update bitnami/postgresql to 12.12.10

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.11.2
+  version: 12.12.10
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.2.9
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.13.2
-digest: sha256:e9c91a845b3f176bc0ab93c7323e50d98fd805c7c7864d1f0a45b4650707c2f5
-generated: "2023-09-16T01:30:49.121548618+02:00"
+digest: sha256:92fe0891c35c2586cfe3b76154412c188bb75cc0a687e1d771fc4c1cf0f8973d
+generated: "2023-11-11T19:19:38.983179104+01:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.4.0
+version: 4.5.0
 appVersion: 27.1.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,7 +23,7 @@ maintainers:
     email: jeff@billimek.com
 dependencies:
   - name: postgresql
-    version: 12.11.*
+    version: 12.12.*
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mariadb


### PR DESCRIPTION
# Pull Request

## Description of the change

This PR updates the `postgresql` dependency from `12.11.2` to `12.12.10` as requested by [this comment](https://github.com/nextcloud/helm/pull/446#issuecomment-1798677453). Notably, it doesn't update to `13.2.5`, as major version PostgreSQL updates tend to require manual intervention, and this would require the chart to be bumped to `5.x`.

## Benefits

This update includes various upstream changes to the `postgresql` dependency.

## Possible drawbacks

This is not the latest version available. However, as described above, updating to `13.x` would require a major version increase.

## Applicable issues

N/A

## Additional information

**Steps to test** (copied from #​446; using minikube):

- Start a fresh cluster:\
  `minikube start -p nextcloud`
- Clone this PR's branch:
  ```
  mkdir nextcloud-helm && cd nextcloud-helm && git init \
  && git pull --depth=1 https://github.com/nextcloud/helm.git refs/pull/446/merge:refs/heads/main
  ```
- Download the dependencies:\
  `cd charts/nextcloud && helm dep build`
- Create `test-values.yaml`:
  ```
  cat << EOF > test-values.yaml
  ingress:
    enabled: true
  externalDatabase:
    enabled: true
    type: postgresql
    host: albacore-postgresql-0:5432
    user: nextcloud
    database: nextcloud
    existingSecret:
      enabled: false
      secretName: postgres-creds
      passwordKey: user
  internalDatabase:
    enabled: false
  postgresql:
    enabled: true
    global:
      postgresql:
        auth:
          existingSecret: postgres-creds
          secretKeys:
            adminPasswordKey: admin
            userPasswordKey: user
            replicationPasswordKey: replication
  EOF
  ```
- Create the secret:\
  `kubectl create secret generic postgres-creds --from-literal=user=foo --from-literal=replication=bar --from-literal=admin=baz --from-literal=db-username=nextcloud`
- Install this PR's chart:\
  `helm install -f test-values.yaml albacore .`
- Test the Nextcloud deployment.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
