### PR TITLE
Update release.yaml - only run release on charts directory changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - 'charts/**/README.md'
-      - 'LICENSE'
-      - 'README.md'
+    paths:
+      - 'charts/**'
 
 jobs:
   release:


### PR DESCRIPTION
# Pull Request

## Description of the change

Accidentally kicked off a release when I added the contributing doc, so this should stop that from happening the future.

## Benefits

This changes `paths-ignore` to just `paths` and then the path is anything under the charts dir.

## Possible drawbacks

If there's a change to ONLY the README in the charts dir, it would still attempt a release and fail, but I think the best thing to do longer term is make the README autogenerated via something like [helm-docs](https://github.com/norwoodj/helm-docs) and move all the other docs currently in the charts/nextcloud/README to the root level readme, but this is also going to be fairly rare, so I'm up for debate :)

## Applicable issues

none

## Additional information

we could also just add CONTRIBUTING.md and CODE_OF_CONDUCT.md to the paths-ignore. Happy to do that instead :)

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
