### PR TITLE
Explicitly sets helm resource policy to keep

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.5.0
+version: 4.5.1
 appVersion: 27.1.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -250,6 +250,7 @@ Is there a missing parameter for one of the Bitnami helm charts listed above? Pl
 
 The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
 Persistent Volume Claims are used to keep the data across deployments. This is known to work with GKE, EKS, K3s, and minikube.
+If the helm chart is uninstalled, nextcloud and it's sub-charts will *not* delete their PVCs. They will need to be manually deleted if desired.
 
 
 | Parameter                                                            | Description                                                                            | Default                                      |

--- a/charts/nextcloud/templates/nextcloud-data-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-data-pvc.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/component: app
 {{- if .Values.persistence.nextcloudData.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
 {{ toYaml .Values.persistence.nextcloudData.annotations | indent 4 }}
 {{- end }}
 spec:

--- a/charts/nextcloud/templates/nextcloud-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-pvc.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/component: app
 {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
 {{ toYaml .Values.persistence.annotations | indent 4 }}
 {{- end }}
 spec:


### PR DESCRIPTION
# Pull Request

## Description of the change

Sets default helm resource policy to 'keep', preventing helm from deleting `nextcloud` and `nextcloud-data` pvcs when uninstalled, in contrast with best practice.

## Benefits

Decreases the chance of unintentional data loss

## Possible drawbacks

Forces users to be intentional about deleting their PVCs. In a certain light, this is a benefit.

## Applicable issues

- fixes #53 

## Additional information

This should be all

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
