### PR TITLE
feat(docs): Document service discovery with nginx and ingress

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.5.4
+version: 4.5.5
 appVersion: 27.1.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -27,6 +27,7 @@ ingress:
   #  nginx.ingress.kubernetes.io/proxy-body-size: 4G
   #  kubernetes.io/tls-acme: "true"
   #  cert-manager.io/cluster-issuer: letsencrypt-prod
+  #  # Keep this in sync with the README.md:
   #  nginx.ingress.kubernetes.io/server-snippet: |-
   #    server_tokens off;
   #    proxy_hide_header X-Powered-By;


### PR DESCRIPTION
# Pull Request

## Description of the change

Documents how to get the service discovery working in case of using nginx and ingress.

## Benefits

People (including me) struggled with the service discovery because it was not documented how to get it working. The server snippet was already in the values, but it was nowhere mentioned that it is needed.

## Possible drawbacks

None, only more documentation.

## Applicable issues

- Fixes https://github.com/nextcloud/helm/issues/410

## Additional information

@qlonik @adborden Please test if this solves your problems (I couldn't directly request a review from you).

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
