### PR TITLE
add mariadb image.registry fallback to docker.io and update docs for mariadb.image parameters

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.5.6
+version: 4.5.7
 appVersion: 27.1.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -231,6 +231,9 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `mariadb.auth.password`                                              | Password for the database                                                              | `changeme`            |
 | `mariadb.auth.rootPassword`                                          | MariaDB admin password                                                                 | `nil`                 |
 | `mariadb.auth.existingSecret`                                        | Use existing secret for MariaDB password details; see values.yaml for more detail      | `''`                  |
+| `mariadb.image.registry`                                             | MariaDB image registry                                                                 | `docker.io`           |
+| `mariadb.image.repository`                                           | MariaDB image repository                                                               | `bitnami/mariadb`     |
+| `mariadb.image.tag`                                                  | MariaDB image tag                                                                      | `15.4.0-debian-11-r10`|
 | `mariadb.primary.persistence.enabled`                                | Whether or not to Use a PVC on MariaDB primary                                         | `false`               |
 | `mariadb.primary.persistence.existingClaim`                          | Use an existing PVC for MariaDB primary                                                | `nil`                 |
 | `postgresql.enabled`                                                 | Whether to use the PostgreSQL chart                                                    | `false`               |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -233,7 +233,7 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `mariadb.auth.existingSecret`                                        | Use existing secret for MariaDB password details; see values.yaml for more detail      | `''`                  |
 | `mariadb.image.registry`                                             | MariaDB image registry                                                                 | `docker.io`           |
 | `mariadb.image.repository`                                           | MariaDB image repository                                                               | `bitnami/mariadb`     |
-| `mariadb.image.tag`                                                  | MariaDB image tag                                                                      | `15.4.0-debian-11-r10`|
+| `mariadb.image.tag`                                                  | MariaDB image tag                                                                      | ``                    |
 | `mariadb.primary.persistence.enabled`                                | Whether or not to Use a PVC on MariaDB primary                                         | `false`               |
 | `mariadb.primary.persistence.existingClaim`                          | Use an existing PVC for MariaDB primary                                                | `nil`                 |
 | `postgresql.enabled`                                                 | Whether to use the PostgreSQL chart                                                    | `false`               |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -279,7 +279,7 @@ spec:
         {{- end }}
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
-          image: {{ .Values.mariadb.image.registry }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
+          image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
           env:
             - name: MYSQL_USER
               valueFrom:


### PR DESCRIPTION
# Pull Request

## Description of the change

This just adds some docs for `mariadb.image` and adds a fallback for the image.registry parameter.

## Benefits

This just makes postgres and mariadb a bit more consistent and adds docs

## Possible drawbacks

we can't reasonably maintain the image tag in the docs, because it would change everytime we update the subcharts, so I've left it blank.

## Applicable issues

This fixes the issue brought up in https://github.com/nextcloud/helm/pull/471#issuecomment-1848316834

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
