### PR TITLE
fix #489 resources indent in README

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.5.11
+version: 4.5.12
 appVersion: 28.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -463,16 +463,16 @@ nextcloud:
   extraVolumeMounts:
     - name: hugepages
       mountPath: /dev/hugepages
-  resources:
-    requests:
-      hugepages-2Mi: 500Mi
-      # note that Kubernetes currently requires cpu or memory requests and limits before hugepages are allowed.
-      memory: 500Mi
-    limits:
-      # limit and request must be the same for hugepages. They are a fixed resource.
-      hugepages-2Mi: 500Mi
-      # note that Kubernetes currently requires cpu or memory requests and limits before hugepages are allowed.
-      memory: 1Gi
+resources:
+  requests:
+    hugepages-2Mi: 500Mi
+    # note that Kubernetes currently requires cpu or memory requests and limits before hugepages are allowed.
+    memory: 500Mi
+  limits:
+    # limit and request must be the same for hugepages. They are a fixed resource.
+    hugepages-2Mi: 500Mi
+    # note that Kubernetes currently requires cpu or memory requests and limits before hugepages are allowed.
+    memory: 1Gi
 ```
 
 ## HPA (Clustering)


### PR DESCRIPTION
# Pull Request

## Description of the change

We remove an indent in the README.md so it matches the values file and the reference in the corresponding helm template file.

## Benefits

The README.md matches the code.

## Possible drawbacks

In general one could argue that having `resources:` outside of the `nextcloud:`-Block in the values is not consistent with other components of the deployment, but for the sake of compatibility fixing the README seems to be appropriate.

## Applicable issues

- fixes #489

## Additional information

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md