### PR TITLE
fix(hooks): configmap does not need base64 encoding

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.0
+version: 4.6.1
 appVersion: 28.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/configmap-hooks.yaml
+++ b/charts/nextcloud/templates/configmap-hooks.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   {{- range $hook, $shell := .Values.nextcloud.hooks }}
   {{- if $shell }}
-  {{ $hook }}.sh: {{ $shell | b64enc }}
+  {{ $hook }}.sh: {{ $shell | quote }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
# Pull Request

## Description of the change
a bug in #525 after change from secret to configmap

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
