### PR TITLE
Fix subPath on datadir mounts (fixes #531)

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.7.0
+version: 5.0.0
 appVersion: 28.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.2
+version: 4.7.0
 appVersion: 28.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -246,11 +246,13 @@ Create volume mounts for the nextcloud container as well as the cron sidecar con
 - name: nextcloud-main
   mountPath: /var/www/html
   subPath: {{ ternary "html" (printf "%s/html" .Values.nextcloud.persistence.subPath) (empty .Values.nextcloud.persistence.subPath) }}
-{{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
+{{- if .Values.persistence.nextcloudData.enabled }}
 - name: nextcloud-data
   mountPath: {{ .Values.nextcloud.datadir }}
-  subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.nextcloudData.subPath) (empty .Values.persistence.nextcloudData.subPath) }}
-{{- else }}
+{{- if not (empty .Values.persistence.nextcloudData.subPath) }}
+  subPath: {{ .Values.persistence.nextcloudData.subPath }}
+{{- end }}
+{{- else if .Values.persistence.enabled }}
 - name: nextcloud-main
   mountPath: {{ .Values.nextcloud.datadir }}
   subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.subPath) (empty .Values.persistence.subPath) }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -215,11 +215,13 @@ spec:
             - name: nextcloud-main
               mountPath: /var/www/html
               subPath: {{ ternary "html" (printf "%s/html" .Values.nextcloud.persistence.subPath) (empty .Values.nextcloud.persistence.subPath) }}
-            {{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
+            {{- if .Values.persistence.nextcloudData.enabled }}
             - name: nextcloud-data
               mountPath: {{ .Values.nextcloud.datadir }}
-              subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.nextcloudData.subPath) (empty .Values.persistence.nextcloudData.subPath) }}
-            {{- else }}
+            {{- if not (empty .Values.persistence.nextcloudData.subPath) }}
+              subPath: {{ .Values.persistence.nextcloudData.subPath }}
+            {{- end }}
+            {{- else if .Values.persistence.enabled }}
             - name: nextcloud-main
               mountPath: {{ .Values.nextcloud.datadir }}
               subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.subPath) (empty .Values.persistence.subPath) }}


### PR DESCRIPTION
- subPath now does not necessarily end on /data, in particular empty subPath possible for datadir on specific PVC
- datadir persistence now does not depend on overall persistence anymore
- bump .minor because old installs will need to add `/data` back to the subPath in the values file

# Pull Request

## Description of the change

Fix #531

The datadir had the subPath-Suffix "/data" forced upon it and it was impossible 

## Possible drawbacks

If someone actually used the a different volume in the past, they will now need to add `/data` to their subPath value.

## Applicable issues

- fixes #531 

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
- [x] tested installing and running fresh nextcloud instance with existing persistent volume for datadir
