### PR TITLE
Update nextcloud appVersion to 28.0.4

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.4
-appVersion: 28.0.3
+version: 4.6.5
+appVersion: 28.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
   - nextcloud


### PR DESCRIPTION
# Pull Request

## Description of the change

Updates nextcloud docker image tag to default to `28.0.4`

## Benefits

latest docker tag

## Possible drawbacks

none that I can think of

## Applicable issues

none that I'm aware of

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
