### PR TITLE
Add: Redis persistent volumes settings to values

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.7.0
+version: 4.6.6
 appVersion: 28.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.5
+version: 4.7.0
 appVersion: 28.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -154,6 +154,9 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `redis.auth.password`                                      | The password redis uses                                                                             | `''`                       |
 | `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                              | `''`                       |
 | `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                                   | `''`                       |
+| `redis.global.storageClass`                                | PVC Storage Class  for both Redis&reg; master and replica Persistent Volumes                        | `''`                       |
+| `redis.master.persistence.enabled`                         | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                        | `true`                     |
+| `redis.replica.persistence.enabled`                        | Enable persistence on Redis&reg; replica nodes using Persistent Volume Claims                       | `true`                     |
 | `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                         | `false`                    |
 | `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                        | `nil`                      |
 | `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                          | `nil`                      |

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -355,6 +355,15 @@ redis:
     existingSecret: ""
     # Password key to be retrieved from existing secret
     existingSecretPasswordKey: ""
+  # Since Redis is used for caching only, you might want to use a storageClass with different reclaim policy and backup settings
+  global:
+    storageClass: ""
+  master:
+    persistence:
+      enabled: true
+  replica:
+    persistence:
+      enabled: true
 
 
 ## Cronjob to execute Nextcloud background tasks


### PR DESCRIPTION
# Pull Request

## Description of the change

Added Redis persistent volume settings to values and the readme. This is only to make users aware of how to change these settings, the PR itself doesn't contain any changes to the functioning of the chart.

## Benefits

It will make people aware of how to change the persistent volume settings for Redis.

## Possible drawbacks

Too many settings in values might "clutter" the values file and readme.

## Applicable issues

- fixes #546

## Additional information

not applicable

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
