### PR TITLE
chore: Prevent displaying constant diffs for nextcloud-token in ArgoCD

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.5
+version: 4.7.0
 appVersion: 28.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.7.0
+version: 4.6.8
 appVersion: 29.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -17,9 +17,9 @@ data:
   {{- else }}
   nextcloud-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
-  {{- with .Values.metrics.token }}
-  nextcloud-token: {{ . | b64enc | quote }}
-  {{- else }}
+  {{- if .Values.metrics.token }}
+  nextcloud-token: {{ .Values.metrics.token | b64enc | quote }}
+  {{- else if .Values.metrics.enabled }}
   nextcloud-token: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.nextcloud.mail.enabled }}

--- a/charts/nextcloud/templates/secrets.yaml
+++ b/charts/nextcloud/templates/secrets.yaml
@@ -17,9 +17,9 @@ data:
   {{- else }}
   nextcloud-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
-  {{- if .Values.metrics.token }}
+  {{- if and .Values.metrics.enabled .Values.metrics.token }}
   nextcloud-token: {{ .Values.metrics.token | b64enc | quote }}
-  {{- else if .Values.metrics.enabled }}
+  {{- else if and .Values.metrics.enabled (not .Values.metrics.token) }}
   nextcloud-token: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.nextcloud.mail.enabled }}


### PR DESCRIPTION
# Pull Request

## Description of the change

When metrics are not enabled, the use of randAlphaNum was causing constant diffs for nextcloud-token in ArgoCD. To mitigate this issue, now nextcloud-token won't be configured when metrics are not enabled.

## Benefits

This change prevents unnecessary diffs in ArgoCD when metrics are not enabled, leading to a cleaner deployment process.

## Possible drawbacks

None

## Applicable issues

- fixes #<issue_number>

## Additional information

None

## Checklist

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
