### PR TITLE
feat: keep PVCs when uninstalling helm chart

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.5
+version: 4.6.6
 appVersion: 28.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -257,6 +257,7 @@ Is there a missing parameter for one of the Bitnami helm charts listed above? Pl
 
 The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
 Persistent Volume Claims are used to keep the data across deployments. This is known to work with GKE, EKS, K3s, and minikube.
+Nextcloud will *not* delete the PVCs when uninstalling the helm chart.
 
 
 | Parameter                                                            | Description                                                                            | Default                                      |

--- a/charts/nextcloud/templates/nextcloud-data-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-data-pvc.yaml
@@ -10,8 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: app
-  {{- with .Values.persistence.nextcloudData.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
+  {{- with .Values.persistence.nextcloudData.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/nextcloud/templates/nextcloud-pvc.yaml
+++ b/charts/nextcloud/templates/nextcloud-pvc.yaml
@@ -9,8 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: app
-  {{- with .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
+  {{- with .Values.persistence.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
# Pull Request

## Description of the change

Keep nextcloud PVCs when uninstalling the helm chart
<!-- Describe the scope of your change - i.e. what the change does. -->

## Benefits

Most helm charts keep PVCs on uninstall. The current nextcloud approach is unexpected and thus may lead to data loss.
Learned that the hard way :sweat_smile: 
<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

None that I'm aware of.
<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #53

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
