### PR TITLE
Set default securityContext for nextcloud-metrics

### DIFF
--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -75,4 +75,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 {{- end }}


### PR DESCRIPTION
Sets best defaults for securityContext on nextcloud-metrics pod and container.

# Pull Request

## Description of the change

Add defaults to the deployment of nextcloud-metrics with selections for securityContext options on both pod and container.

## Benefits

Clusters with higher security configurations can run nextcloud with metrics enabled.

## Possible drawbacks

Unknown, if any.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md