### PR TITLE
Allow to set environment variables to Nginx container

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.8
+version: 4.6.9
 appVersion: 29.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -147,6 +147,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nginx.config.custom`                                      | Specify a custom config for nginx                                                                   | `{}`                       |
 | `nginx.resources`                                          | nginx resources                                                                                     | `{}`                       |
 | `nginx.securityContext`                                    | Optional security context for the nginx container                                                   | `nil`                      |
+| `nginx.extraEnv`                                           | Optional environment variables for the nginx container                                              | `nil`                      |
 | `lifecycle.postStartCommand`                               | Specify deployment lifecycle hook postStartCommand                                                  | `nil`                      |
 | `lifecycle.preStopCommand`                                 | Specify deployment lifecycle hook preStopCommand                                                    | `nil`                      |
 | `redis.enabled`                                            | Whether to install/use redis for locking                                                            | `false`                    |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
         - name: {{ .Chart.Name }}-nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          {{- with .Values.nginx.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -245,6 +245,11 @@ nginx:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
+  ## Extra environment variables
+  extraEnv: []
+  #  - name: SOME_ENV
+  #    value: ENV_VALUE
+
 internalDatabase:
   enabled: true
   name: nextcloud


### PR DESCRIPTION
# Pull Request

## Description of the change

Add the `nginx.extraEnv` parameter allowing to pass environment variables to the Nginx container. 

## Benefits

This is for example useful to set the timezone of the Nginx container through  *TZ* environment variable  (cf #494 and https://github.com/nginxinc/docker-nginx/issues/149).

## Possible drawbacks

None, the new parameter is optional.

## Applicable issues

- fixes #494 

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
