### PR TITLE
only run chart linting for specific files instead of trying to catch every exception

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,6 +23,7 @@ jobs:
 
   lint-test:
     runs-on: ubuntu-22.04
+    needs: changes
     if: needs.changes.outputs.src != 'false'
     steps:
       - name: Checkout

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,12 +3,27 @@ name: Lint and Test Charts
 on:
   pull_request:
     paths:
-      - 'charts/nextcloud/Chart.yaml'
-      - 'charts/nextcloud/values.yaml'
-      - 'charts/nextcloud/templates/**'
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - 'charts/nextcloud/Chart.yaml'
+              - 'charts/nextcloud/values.yaml'
+              - 'charts/nextcloud/templates/**'
+
   lint-test:
     runs-on: ubuntu-22.04
+    if: needs.changes.outputs.src != 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,3 +63,17 @@ jobs:
         id: install
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    if: always()
+    needs: [changes]
+
+    # This is the summary, we just avoid to rename it so that branch protection rules still match
+    name: Lint and Test Charts
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' }}; then exit 1; fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,14 +2,10 @@ name: Lint and Test Charts
 
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'charts/**/README.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - 'README.md'
-
+    paths:
+      - 'charts/nextcloud/Chart.yaml'
+      - 'charts/nextcloud/values.yaml'
+      - 'charts/nextcloud/templates/**'
 jobs:
   lint-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -64,17 +64,3 @@ jobs:
         id: install
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
-
-  summary:
-    permissions:
-      contents: none
-    runs-on: ubuntu-latest-low
-    if: always()
-    needs: [changes]
-
-    # This is the summary, we just avoid to rename it so that branch protection rules still match
-    name: Lint and Test Charts
-
-    steps:
-      - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' }}; then exit 1; fi


### PR DESCRIPTION
# Pull Request

## Description of the change

Only run the chart linting action for:
- `charts/nextcloud/Chart.yaml`
- `charts/nextcloud/values.yaml`
- `charts/nextcloud/templates/**` (everything in the templates directory)

## Benefits

This is better than trying to manually exclude all the possible things we don't want to run it on.

## Possible drawbacks

Can't think of any.

## Additional information

This would fix the issue where this PR, https://github.com/nextcloud/helm/pull/574, is trying to run the chart linter 🤦 

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
