### PR TITLE
Update Postgresql, MariaDB, and Redis subcharts to the latest (⚠️ Major updates)

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -5,7 +5,7 @@ on:
     paths:
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-low
 
     outputs:
       src: ${{ steps.changes.outputs.src}}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -73,11 +73,21 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         id: install
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
 
   test-postgresql-database:
@@ -97,11 +107,21 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         id: install
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
             ct install --target-branch ${{ github.event.repository.default_branch }} \
             --helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing123456"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -5,7 +5,7 @@ on:
     paths:
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-22.04
 
     outputs:
       src: ${{ steps.changes.outputs.src}}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
               - 'charts/nextcloud/values.yaml'
               - 'charts/nextcloud/templates/**'
 
-  lint-test:
+  lint:
     runs-on: ubuntu-22.04
     needs: changes
     if: needs.changes.outputs.src != 'false'
@@ -56,11 +56,28 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
+  test-internal-database:
+    runs-on: ubuntu-22.04
+    needs: [changes, lint]
+    if: needs.changes.outputs.src != 'false'
+    steps:
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
-        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         id: install
-        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
+  test-postgresql-database:
+    runs-on: ubuntu-22.04
+    needs: [changes, lint]
+    if: needs.changes.outputs.src != 'false'
+    steps:
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+
+      - name: Run chart-testing (install)
+        id: install
+        run: |
+            ct install --target-branch ${{ github.event.repository.default_branch }} \
+            --helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing123456"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -61,6 +61,11 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.src != 'false'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
@@ -95,6 +100,11 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.src != 'false'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -61,6 +61,18 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.src != 'false'
     steps:
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
 
@@ -73,6 +85,18 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.src != 'false'
     steps:
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.10.0
 

--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.12.10
+  version: 15.5.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.2.9
+  version: 18.2.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.13.2
-digest: sha256:92fe0891c35c2586cfe3b76154412c188bb75cc0a687e1d771fc4c1cf0f8973d
-generated: "2023-11-11T19:19:38.983179104+01:00"
+  version: 19.5.0
+digest: sha256:4efc098feeb7f4486b7166f1c71b9c54bfee0797663a3339f379d397297303c7
+generated: "2024-06-03T09:51:56.321676+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.6.10
+version: 5.0.0
 appVersion: 29.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -23,14 +23,14 @@ maintainers:
     email: jeff@billimek.com
 dependencies:
   - name: postgresql
-    version: 12.12.*
+    version: 15.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mariadb
-    version: 12.2.*
+    version: 18.2.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: mariadb.enabled
   - name: redis
-    version: 17.13.*
+    version: 19.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled


### PR DESCRIPTION
# ⚠️ Major updates to sub charts

## Description of the change

- Updates postgresql chart from `12.12.10` to `15.5.0`
- Updates mariadb chart from `12.2.9` to `18.2.0`
- Updates redis chart from `17.13.*` to `19.5.0`
- Adds a new job to test postgresql installs

As always, you need to check the official upgrade instructions from both bitnami and the upstream providers. Please see the following docs before attempting the nextcloud helm chart upgrade:

- https://github.com/bitnami/charts/tree/main/bitnami/postgresql#to-1300
- https://github.com/bitnami/charts/tree/main/bitnami/mariadb#to-1400
- https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1800

## Benefits

We were pretty out of date on all our subcharts, and this also grants us an end to end test with postgresql, which we've been missing for a while.

## Possible drawbacks

- I don't have a test for mysql, only because I don't actually use mariadb, and don't have the time to create one right now, but if others want to submit that test, I'd be open to testing it locally :)
- users will need to still follow the major upgrade docs listed above before they can upgrade, as is the case for all major upgrades of redis, mariadb, and postgresql
- I have hardcoded a password for the testing of postgresql. We can easily update this to be a repo secret and then no password will be logged, but that requires someone with better access than myself to add that repo secret, and then tell me know what the name of it is, so I can update the `ct` command.

## Applicable issues

I feel like we had an issue for postgresql testing, but I can't find it right now 🤔 

## Additional information

You can see an example of the new testing workflow here where I ran it on my personal repo for this feature branch:
https://github.com/jessebot/nextcloud-helm/actions/runs/9347132143
<img width="951" alt="Screenshot of the summary section for the jessebot/nextcloud-helm feature branch workflow showing 4 jobs. The first job is the changes job, which then feeds into the linting job, which then triggers both the internal-database test and postgresql-database test. All 4 show as green, meaning success." src="https://github.com/nextcloud/helm/assets/2389292/4f95ae73-5c75-470f-b875-8f8338991380">

In the future, renovateBot will take care of these updates for us, and then we just need to review them. I'm doing this manually now, because we're so very behind.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
