### PR TITLE
Add setting of NEXTCLOUD_SERVER and NEXTCLOUD_INFO_APPS for metrics exporter and clean up docs

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.1.0
+version: 5.2.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -210,46 +210,46 @@ For convenience, we packages the following Bitnami charts for databases (feel fr
 If you choose to use one of the prepackaged Bitnami helm charts, you must configure both the `externalDatabase` parameters, and the parameters for the chart you choose. For instance, if you choose to use the Bitnami PostgreSQL chart that we've prepackaged, you need to also configure all the parameters for `postgresql`. You do not need to use the Bitnami helm charts. If you want to use an already configured database that you have externally, just set `internalDatabase.enabled` to `false`, and configure the `externalDatabase` parameters below.
 
 
-| Parameter                                                            | Description                                                                            | Default               |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|-----------------------|
-| `internalDatabase.enabled`                                           | Whether to use internal sqlite database                                                | `true`                |
-| `internalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`           |
-| `externalDatabase.enabled`                                           | Whether to use external database                                                       | `false`               |
-| `externalDatabase.type`                                              | External database type: `mysql`, `postgresql`                                          | `mysql`               |
-| `externalDatabase.host`                                              | Host of the external database in form of `host:port`                                   | `nil`                 |
-| `externalDatabase.database`                                          | Name of the existing database                                                          | `nextcloud`           |
-| `externalDatabase.user`                                              | Existing username in the external db                                                   | `nextcloud`           |
-| `externalDatabase.password`                                          | Password for the above username                                                        | `nil`                 |
-| `externalDatabase.existingSecret.enabled`                            | Whether to use a existing secret or not                                                | `false`               |
-| `externalDatabase.existingSecret.secretName`                         | Name of the existing secret                                                            | `nil`                 |
-| `externalDatabase.existingSecret.usernameKey`                        | Name of the key that contains the username                                             | `nil`                 |
-| `externalDatabase.existingSecret.passwordKey`                        | Name of the key that contains the password                                             | `nil`                 |
-| `externalDatabase.existingSecret.hostKey`                            | Name of the key that contains the database hostname or IP address                      | `nil`                 |
-| `externalDatabase.existingSecret.databaseKey`                        | Name of the key that contains the database name                                        | `nil`                 |
-| `mariadb.enabled`                                                    | Whether to use the MariaDB chart                                                       | `false`               |
-| `mariadb.auth.database`                                              | Database name to create                                                                | `nextcloud`           |
-| `mariadb.auth.username`                                              | Database user to create                                                                | `nextcloud`           |
-| `mariadb.auth.password`                                              | Password for the database                                                              | `changeme`            |
-| `mariadb.auth.rootPassword`                                          | MariaDB admin password                                                                 | `nil`                 |
-| `mariadb.auth.existingSecret`                                        | Use existing secret for MariaDB password details; see values.yaml for more detail      | `''`                  |
-| `mariadb.image.registry`                                             | MariaDB image registry                                                                 | `docker.io`           |
-| `mariadb.image.repository`                                           | MariaDB image repository                                                               | `bitnami/mariadb`     |
-| `mariadb.image.tag`                                                  | MariaDB image tag                                                                      | ``                    |
-| `mariadb.primary.persistence.enabled`                                | Whether or not to Use a PVC on MariaDB primary                                         | `false`               |
-| `mariadb.primary.persistence.existingClaim`                          | Use an existing PVC for MariaDB primary                                                | `nil`                 |
-| `postgresql.enabled`                                                 | Whether to use the PostgreSQL chart                                                    | `false`               |
-| `postgresql.image.registry`                                          | PostgreSQL image registry                                                              | `docker.io`           |
-| `postgresql.image.repository`                                        | PostgreSQL image repository                                                            | `bitnami/postgresql`  |
-| `postgresql.image.tag`                                               | PostgreSQL image tag                                                                   | `15.4.0-debian-11-r10`|
-| `postgresql.global.postgresql.auth.database`                         | Database name to create                                                                | `nextcloud`           |
-| `postgresql.global.postgresql.auth.username`                         | Database user to create                                                                | `nextcloud`           |
-| `postgresql.global.postgresql.auth.password`                         | Password for the database                                                              | `changeme`            |
-| `postgresql.global.postgresql.auth.existingSecret`                   | Name of existing secret to use for PostgreSQL credentials                              | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.adminPasswordKey`      | Name of key in existing secret to use for PostgreSQL admin password                    | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.userPasswordKey`       | Name of key in existing secret to use for PostgreSQL user password                     | `''`                  |
-| `postgresql.global.postgresql.auth.secretKeys.replicationPasswordKey`| Name of key in existing secret to use for PostgreSQL replication password              | `''`                  |
-| `postgresql.primary.persistence.enabled`                             | Whether or not to use PVC on PostgreSQL primary                                        | `false`               |
-| `postgresql.primary.persistence.existingClaim`                       | Use an existing PVC for PostgreSQL primary                                             | `nil`                 |
+| Parameter                                                             | Description                                                                       | Default                |
+|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|------------------------|
+| `internalDatabase.enabled`                                            | Whether to use internal sqlite database                                           | `true`                 |
+| `internalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
+| `externalDatabase.enabled`                                            | Whether to use external database                                                  | `false`                |
+| `externalDatabase.type`                                               | External database type: `mysql`, `postgresql`                                     | `mysql`                |
+| `externalDatabase.host`                                               | Host of the external database in form of `host:port`                              | `nil`                  |
+| `externalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
+| `externalDatabase.user`                                               | Existing username in the external db                                              | `nextcloud`            |
+| `externalDatabase.password`                                           | Password for the above username                                                   | `nil`                  |
+| `externalDatabase.existingSecret.enabled`                             | Whether to use a existing secret or not                                           | `false`                |
+| `externalDatabase.existingSecret.secretName`                          | Name of the existing secret                                                       | `nil`                  |
+| `externalDatabase.existingSecret.usernameKey`                         | Name of the key that contains the username                                        | `nil`                  |
+| `externalDatabase.existingSecret.passwordKey`                         | Name of the key that contains the password                                        | `nil`                  |
+| `externalDatabase.existingSecret.hostKey`                             | Name of the key that contains the database hostname or IP address                 | `nil`                  |
+| `externalDatabase.existingSecret.databaseKey`                         | Name of the key that contains the database name                                   | `nil`                  |
+| `mariadb.enabled`                                                     | Whether to use the MariaDB chart                                                  | `false`                |
+| `mariadb.auth.database`                                               | Database name to create                                                           | `nextcloud`            |
+| `mariadb.auth.username`                                               | Database user to create                                                           | `nextcloud`            |
+| `mariadb.auth.password`                                               | Password for the database                                                         | `changeme`             |
+| `mariadb.auth.rootPassword`                                           | MariaDB admin password                                                            | `nil`                  |
+| `mariadb.auth.existingSecret`                                         | Use existing secret for MariaDB password details; see values.yaml for more detail | `''`                   |
+| `mariadb.image.registry`                                              | MariaDB image registry                                                            | `docker.io`            |
+| `mariadb.image.repository`                                            | MariaDB image repository                                                          | `bitnami/mariadb`      |
+| `mariadb.image.tag`                                                   | MariaDB image tag                                                                 | ``                     |
+| `mariadb.primary.persistence.enabled`                                 | Whether or not to Use a PVC on MariaDB primary                                    | `false`                |
+| `mariadb.primary.persistence.existingClaim`                           | Use an existing PVC for MariaDB primary                                           | `nil`                  |
+| `postgresql.enabled`                                                  | Whether to use the PostgreSQL chart                                               | `false`                |
+| `postgresql.image.registry`                                           | PostgreSQL image registry                                                         | `docker.io`            |
+| `postgresql.image.repository`                                         | PostgreSQL image repository                                                       | `bitnami/postgresql`   |
+| `postgresql.image.tag`                                                | PostgreSQL image tag                                                              | `15.4.0-debian-11-r10` |
+| `postgresql.global.postgresql.auth.database`                          | Database name to create                                                           | `nextcloud`            |
+| `postgresql.global.postgresql.auth.username`                          | Database user to create                                                           | `nextcloud`            |
+| `postgresql.global.postgresql.auth.password`                          | Password for the database                                                         | `changeme`             |
+| `postgresql.global.postgresql.auth.existingSecret`                    | Name of existing secret to use for PostgreSQL credentials                         | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL admin password               | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL user password                | `''`                   |
+| `postgresql.global.postgresql.auth.secretKeys.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL replication password         | `''`                   |
+| `postgresql.primary.persistence.enabled`                              | Whether or not to use PVC on PostgreSQL primary                                   | `false`                |
+| `postgresql.primary.persistence.existingClaim`                        | Use an existing PVC for PostgreSQL primary                                        | `nil`                  |
 
 Is there a missing parameter for one of the Bitnami helm charts listed above? Please feel free to submit a PR to add that parameter in our values.yaml, but be sure to also update this README file :)
 
@@ -261,50 +261,53 @@ Persistent Volume Claims are used to keep the data across deployments. This is k
 Nextcloud will *not* delete the PVCs when uninstalling the helm chart.
 
 
-| Parameter                                                            | Description                                                                            | Default                                      |
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------|
-| `persistence.enabled`                                                | Enable persistence using PVC                                                           | `false`                                      |
-| `persistence.annotations`                                            | PVC annotations                                                                        | `{}`                                         |
-| `persistence.storageClass`                                           | PVC Storage Class for nextcloud volume                                                 | `nil` (uses alpha storage class annotation)  |
-| `persistence.existingClaim`                                          | An Existing PVC name for nextcloud volume                                              | `nil` (uses alpha storage class annotation)  |
-| `persistence.accessMode`                                             | PVC Access Mode for nextcloud volume                                                   | `ReadWriteOnce`                              |
-| `persistence.size`                                                   | PVC Storage Request for nextcloud volume                                               | `8Gi`                                        |
-| `persistence.nextcloudData.enabled`                                  | Create a second PVC for the data folder in nextcloud                                   | `false`                                      |
-| `persistence.nextcloudData.annotations`                              | see `persistence.annotations`                                                          | `{}`                                         |
-| `persistence.nextcloudData.storageClass`                             | see `persistence.storageClass`                                                         | `nil` (uses alpha storage class annotation)  |
-| `persistence.nextcloudData.existingClaim`                            | see `persistence.existingClaim`                                                        | `nil` (uses alpha storage class annotation)  |
-| `persistence.nextcloudData.accessMode`                               | see `persistence.accessMode`                                                           | `ReadWriteOnce`                              |
-| `persistence.nextcloudData.size`                                     | see `persistence.size`                                                                 | `8Gi`                                        |
+| Parameter                                 | Description                                          | Default                                     |
+|-------------------------------------------|------------------------------------------------------|---------------------------------------------|
+| `persistence.enabled`                     | Enable persistence using PVC                         | `false`                                     |
+| `persistence.annotations`                 | PVC annotations                                      | `{}`                                        |
+| `persistence.storageClass`                | PVC Storage Class for nextcloud volume               | `nil` (uses alpha storage class annotation) |
+| `persistence.existingClaim`               | An Existing PVC name for nextcloud volume            | `nil` (uses alpha storage class annotation) |
+| `persistence.accessMode`                  | PVC Access Mode for nextcloud volume                 | `ReadWriteOnce`                             |
+| `persistence.size`                        | PVC Storage Request for nextcloud volume             | `8Gi`                                       |
+| `persistence.nextcloudData.enabled`       | Create a second PVC for the data folder in nextcloud | `false`                                     |
+| `persistence.nextcloudData.annotations`   | see `persistence.annotations`                        | `{}`                                        |
+| `persistence.nextcloudData.storageClass`  | see `persistence.storageClass`                       | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.existingClaim` | see `persistence.existingClaim`                      | `nil` (uses alpha storage class annotation) |
+| `persistence.nextcloudData.accessMode`    | see `persistence.accessMode`                         | `ReadWriteOnce`                             |
+| `persistence.nextcloudData.size`          | see `persistence.size`                               | `8Gi`                                       |
 
 
 ### Metrics Configurations
 
 We include an optional experimental Nextcloud Metrics exporter from [xperimental/nextcloud-exporter](https://github.com/xperimental/nextcloud-exporter).
 
-| Parameter                              | Description                                                                  | Default                                                      |
-|----------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                      | Start Prometheus metrics exporter                                            | `false`                                                      |
-| `metrics.https`                        | Defines if https is used to connect to nextcloud                             | `false` (uses http)                                          |
-| `metrics.token`                        | Uses token for auth instead of username/password                             | `""`                                                         |
-| `metrics.timeout`                      | When the scrape times out                                                    | `5s`                                                         |
-| `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                           | `false`                                                      |
-| `metrics.image.repository`             | Nextcloud metrics exporter image name                                        | `xperimental/nextcloud-exporter`                             |
-| `metrics.image.tag`                    | Nextcloud metrics exporter image tag                                         | `0.6.2`                                                      |
-| `metrics.image.pullPolicy`             | Nextcloud metrics exporter image pull policy                                 | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`            | Nextcloud metrics exporter image pull secrets                                | `nil`                                                        |
-| `metrics.podAnnotations`               | Additional annotations for metrics exporter                                  | not set                                                      |
-| `metrics.podLabels`                    | Additional labels for metrics exporter                                       | not set                                                      |
-| `metrics.service.type`                 | Metrics: Kubernetes Service type                                             | `ClusterIP`                                                  |
-| `metrics.service.loadBalancerIP`       | Metrics: LoadBalancerIp for service type LoadBalancer                        | `nil`                                                        |
-| `metrics.service.nodePort`             | Metrics: NodePort for service type NodePort                                  | `nil`                                                        |
-| `metrics.service.annotations`          | Additional annotations for service metrics exporter                          | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
-| `metrics.service.labels`               | Additional labels for service metrics exporter                               | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                                                      |
-| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                     | ``                                                           |
-| `metrics.serviceMonitor.jobLabel`      | Name of the label on the target service to use as the job name in prometheus | ``                                                           |
-| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                  | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                          | ``                                                           |
-| `metrics.serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                          | `{}                                                          |
+| Parameter                              | Description                                                                         | Default                                                      |
+|----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                      | Start Prometheus metrics exporter                                                   | `false`                                                      |
+| `metrics.replicaCount`                 | Number of nextcloud-metrics pod replicas to deploy                                  | `1`                                                          |
+| `metrics.server`                       | Nextcloud Server URL to get metrics from. If not provided, defaults to service name | `""`                                                         |
+| `metrics.https`                        | Defines if https is used to connect to nextcloud                                    | `false` (uses http)                                          |
+| `metrics.token`                        | Uses token for auth instead of username/password                                    | `""`                                                         |
+| `metrics.timeout`                      | When the scrape times out                                                           | `5s`                                                         |
+| `metrics.tlsSkipVerify`                | Skips certificate verification of Nextcloud server                                  | `false`                                                      |
+| `metrics.info.apps`                    | Enable gathering of apps-related metrics.                                           | `false`                                                      |
+| `metrics.image.repository`             | Nextcloud metrics exporter image name                                               | `xperimental/nextcloud-exporter`                             |
+| `metrics.image.tag`                    | Nextcloud metrics exporter image tag                                                | `0.6.2`                                                      |
+| `metrics.image.pullPolicy`             | Nextcloud metrics exporter image pull policy                                        | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`            | Nextcloud metrics exporter image pull secrets                                       | `nil`                                                        |
+| `metrics.podAnnotations`               | Additional annotations for metrics exporter                                         | not set                                                      |
+| `metrics.podLabels`                    | Additional labels for metrics exporter                                              | not set                                                      |
+| `metrics.service.type`                 | Metrics: Kubernetes Service type                                                    | `ClusterIP`                                                  |
+| `metrics.service.loadBalancerIP`       | Metrics: LoadBalancerIp for service type LoadBalancer                               | `nil`                                                        |
+| `metrics.service.nodePort`             | Metrics: NodePort for service type NodePort                                         | `nil`                                                        |
+| `metrics.service.annotations`          | Additional annotations for service metrics exporter                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
+| `metrics.service.labels`               | Additional labels for service metrics exporter                                      | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator        | `false`                                                      |
+| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                            | ``                                                           |
+| `metrics.serviceMonitor.jobLabel`      | Name of the label on the target service to use as the job name in prometheus        | ``                                                           |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                         | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                                 | ``                                                           |
+| `metrics.serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                                 | `{}                                                          |
 
 
 
@@ -394,7 +397,7 @@ nginx
 
 ### Service discovery with nginx and ingress
 
-For service discovery (CalDAV, CardDAV, webfinger, nodeinfo) to work you need to add redirects to your ingress.  
+For service discovery (CalDAV, CardDAV, webfinger, nodeinfo) to work you need to add redirects to your ingress.
 If you use the [ingress-nginx](https://github.com/kubernetes/ingress-nginx) you can use the following server snippet annotation:
 
 <!-- Keep this in sync with the values.yaml -->
@@ -515,10 +518,10 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ recognize:down
 ```
 
 # Backups
-Check out the [official Nextcloud backup docs](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). For your files, if you're using persistent volumes, and you'd like to back up to s3 backed storage (such as minio), consider using [k8up](https://github.com/k8up-io/k8up) or [velero](https://github.com/vmware-tanzu/velero). 
+Check out the [official Nextcloud backup docs](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). For your files, if you're using persistent volumes, and you'd like to back up to s3 backed storage (such as minio), consider using [k8up](https://github.com/k8up-io/k8up) or [velero](https://github.com/vmware-tanzu/velero).
 
 # Upgrades
-Since this chart utilizes the [nextcloud/docker](https://github.com/nextcloud/docker) image, provided you are using persistent volumes, [upgrades of your Nextcloud server are handled automatically](https://github.com/nextcloud/docker#update-to-a-newer-version) from one version to the next, however, you can only upgrade one major version at a time. For example, if you want to upgrade from version `25` to `27`, you will have to upgrade from version `25` to `26`, then from `26` to `27`. Since our docker tag is set via the [`appVersion` in `Chart.yaml`](https://github.com/nextcloud/helm/blob/main/charts/nextcloud/Chart.yaml#L4), you'll need to make sure you gradually upgrade the helm chart if you have missed serveral app versions. 
+Since this chart utilizes the [nextcloud/docker](https://github.com/nextcloud/docker) image, provided you are using persistent volumes, [upgrades of your Nextcloud server are handled automatically](https://github.com/nextcloud/docker#update-to-a-newer-version) from one version to the next, however, you can only upgrade one major version at a time. For example, if you want to upgrade from version `25` to `27`, you will have to upgrade from version `25` to `26`, then from `26` to `27`. Since our docker tag is set via the [`appVersion` in `Chart.yaml`](https://github.com/nextcloud/helm/blob/main/charts/nextcloud/Chart.yaml#L4), you'll need to make sure you gradually upgrade the helm chart if you have missed serveral app versions.
 
 ⚠️ *Before Upgrading Nextcloud or the attached database, always make sure you take [backups](#backups)!*
 

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -59,12 +59,19 @@ spec:
                   key: {{ .Values.nextcloud.existingSecret.passwordKey }}
             {{- end }}
             # NEXTCLOUD_SERVER is used by metrics-exporter to reach the Nextcloud (K8s-)Service to grab the serverinfo api endpoint
+            {{- if not .Values.metrics.server }}
             - name: NEXTCLOUD_SERVER # deployment.namespace.svc.cluster.local
               value: "http{{ if .Values.metrics.https }}s{{ end }}://{{ template "nextcloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+            {{- else }}
+            - name: NEXTCLOUD_SERVER
+              value: {{ .Values.metrics.server }}
+            {{- end }}
             - name: NEXTCLOUD_TIMEOUT
               value: {{ .Values.metrics.timeout }}
             - name: NEXTCLOUD_TLS_SKIP_VERIFY
               value: {{ .Values.metrics.tlsSkipVerify | quote }}
+            - name: NEXTCLOUD_INFO_APPS
+              value: {{ .Values.metrics.info.apps | quote }}
           ports:
             - name: metrics
               containerPort: 9205

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -497,6 +497,9 @@ metrics:
   enabled: false
 
   replicaCount: 1
+  # Optional: becomes NEXTCLOUD_SERVER env var in the nextcloud-exporter container.
+  # Without it, we will use the full name of the nextcloud service
+  server: ""
   # The metrics exporter needs to know how you serve Nextcloud either http or https
   https: false
   # Use API token if set, otherwise fall back to password authentication
@@ -506,6 +509,10 @@ metrics:
   timeout: 5s
   # if set to true, exporter skips certificate verification of Nextcloud server.
   tlsSkipVerify: false
+  info:
+    # Optional: becomes NEXTCLOUD_INFO_APPS env var in the nextcloud-exporter container.
+    # Enables gathering of apps-related metrics. Defaults to false
+    apps: false
 
   image:
     repository: xperimental/nextcloud-exporter


### PR DESCRIPTION
# Pull Request

## Description of the change

This is an update to the `metrics` section of the values.yaml. This PR covers:

- adds *optionally* setting `NEXTCLOUD_SERVER` via the `metrics.server` parameter, instead of allowing the chart to template it out from the k8s service. If not provided, we still use the service name

- adds setting `NEXTCLOUD_INFO_APPS` via the `metrics.info.apps` parameter, which "Enables gathering of apps-related metrics". Defaults to false as it does in the actual container.

- adds `metrics.replicaCount` to the README, as it was missing

- formats the tables in the README (because my linter did it by default 😅 )

## Benefits

This allows users to get more granular when playing with the metrics exporter container.

## Possible drawbacks

none that I can see immediately. open to chatting as usual :)

## Applicable issues

not sure we have any issues on this yet?

## Additional information

See docs here: https://github.com/xperimental/nextcloud-exporter?tab=readme-ov-file#environment-variables

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Variables are documented in the README.md
