### PR TITLE
Update pull_request_template.md - remove top header + add link to contributing docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# Pull Request
-
 ## Description of the change
 
 <!-- Describe the scope of your change - i.e. what the change does. -->
@@ -23,6 +21,7 @@
 
 ## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
 
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
 - [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
-- [ ] (optional) Variables are documented in the README.md
+- [ ] (optional) Parameters are documented in the README.md


### PR DESCRIPTION
# Pull Request

## Description of the change

This removes the top header of "Pull Request" and adds a link to the CONTRIBUTING docs into the template.

## Benefits

We already know it's a pull request, so we don't need the extra text. This will allow users to get familiar with our contributing docs, which provide further info on allowing edits by maintainers, for instance.

## Possible drawbacks

None that I can think of, but happy to chat about it. This is a low priority PR.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Variables are documented in the README.md
