### PR TITLE
Add possibility to configure custom `dnsConfig` on the Nextcloud pod

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.2.2
+version: 5.3.0
 appVersion: 29.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -202,6 +202,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `deploymentAnnotations`                                    | Annotations to be added at 'deployment' level                                                       | not set                    |
 | `podLabels`                                                | Labels to be added at 'pod' level                                                                   | not set                    |
 | `podAnnotations`                                           | Annotations to be added at 'pod' level                                                              | not set                    |
+| `dnsConfig`                                                | Custom dnsConfig for nextcloud containers                                                           | `{}`                       |
 
 
 ### Database Configurations

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -396,3 +396,7 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -502,6 +502,12 @@ tolerations: []
 
 affinity: {}
 
+dnsConfig: {}
+# Custom dns config for Nextcloud containers.
+# You can for example configure ndots. This may be needed in some clusters with alpine images.
+# options:
+#   - name: ndots
+#     value: "1"
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
## Description of the change

The change allowes to configure dnsOptions on all nextcloud pods

## Benefits

In some Clusters this option needs to be set. For example k3s clusters can have problems running alpine images.

## Possible drawbacks

None

## Applicable issues

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Parameters are documented in the README.md
