### PR TITLE
add documentation section on adjusting php.ini values

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -22,15 +22,24 @@ helm install my-release nextcloud/nextcloud
 * [Cron jobs](#cron-jobs)
 * [Multiple config.php file](#multiple-configphp-file)
 * [Using nginx](#using-nginx)
+    * [Service discovery with nginx and ingress](#service-discovery-with-nginx-and-ingress)
 * [Preserving Source IP](#preserving-source-ip)
 * [Hugepages](#hugepages)
 * [HPA (Clustering)](#hpa-clustering)
+* [Adjusting PHP ini values](#adjusting-php-ini-values)
 * [Running `occ` commands](#running-occ-commands)
     * [Putting Nextcloud into maintanence mode](#putting-nextcloud-into-maintanence-mode)
     * [Downloading models for recognize](#downloading-models-for-recognize)
 * [Backups](#backups)
 * [Upgrades](#upgrades)
 * [Troubleshooting](#troubleshooting)
+    * [Logging](#logging)
+        * [Changing the logging behavior](#changing-the-logging-behavior)
+        * [Viewing the logs](#viewing-the-logs)
+            * [Exec into the kubernetes pod:](#exec-into-the-kubernetes-pod)
+            * [Then look for the `nextcloud.log` file with tail or cat:](#then-look-for-the-nextcloudlog-file-with-tail-or-cat)
+            * [Copy the log file to your local machine:](#copy-the-log-file-to-your-local-machine)
+        * [Sharing the logs](#sharing-the-logs)
 
 ## Introduction
 
@@ -493,6 +502,20 @@ persistence:
   enabled: true
   accessMode: ReadWriteMany
 ```
+
+## Adjusting PHP ini values
+
+Sometimes you may need special [`php.ini`](https://www.php.net/manual/en/ini.list.php) values. For instance, perhaps your setup requires a bit more memory. You can add additional `php.ini` files in the values.yaml by providing `nextcloud.phpConfigs.NAME_OF_FILE`. Here's an examples:
+
+```yaml
+nextcloud:
+  phpConfigs:
+    zz-memory_limit.ini: |-
+      memory_limit=512M
+```
+
+> [!Note]
+> Be sure to prefix your file name with `zz` to ensure it is loaded at the end.
 
 
 ## Running `occ` commands


### PR DESCRIPTION
## Description of the change

Add docs on changing php.ini values. Also regenerates the table of contents "Quick Links".

## Benefits

This may otherwise be hard to find in our values.yaml or giant parameters config tables, so with a quick link, maybe others can more quickly access this info.

## Possible drawbacks

none that I can think of, but happy to take feedback :)

## Applicable issues

- fixes #582

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
