### PR TITLE
only set `spec.replicas` in Nextcloud Deployment if `.Values.hpa.enabled` is set to `false`

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # test the helm chart with horizontal pod autoscaling enabled
           - name: Horizontal Pod Autoscaling Enabled
-            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=1 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=2 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
 
     steps:
       - name: Checkout

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.3.0
+version: 5.3.1
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -203,7 +203,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `startupProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
 | `startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `30`                       |
 | `startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler                                                         | `false`                    |
+| `hpa.enabled`                                              | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
 | `hpa.cputhreshold`                                         | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
 | `hpa.minPods`                                              | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
 | `hpa.maxPods`                                              | Max. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `10`                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.nextcloud.strategy | nindent 4 }}
   selector:


### PR DESCRIPTION
## Description of the change

- Sets`spec.replicas` in Nextcloud Deployment _only if_ `hpa.enabled` in values.yaml is set to `false`.
- update hpa ci test to use `hpa.minPods=2`

## Benefits

This _should_ unbreak the environments that use `hpa.enabled` in their values.yaml that also use Argo CD?

## Possible drawbacks

None that I can think of after #598 was merged! Open to discussion on this one as always :)

## Applicable issues

- fixes #561

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
