### PR TITLE
Refactor lint-test.yaml GHA Workflow to use a matrix for test job generation; Add `nginx.enabled` and `hpa.enabled` tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
               - 'charts/nextcloud/templates/**'
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-low
     needs: changes
     if: needs.changes.outputs.src != 'false'
     steps:
@@ -56,10 +56,32 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
-  test-internal-database:
+  run-tests:
     runs-on: ubuntu-22.04
     needs: [changes, lint]
+    # only run this job if there are helm chart file changes
     if: needs.changes.outputs.src != 'false'
+    strategy:
+      # continue with all the other jobs even if one fails
+      fail-fast: false
+      matrix:
+        # each item in this list is a job with an isolated test VM
+        test_cases:
+          # test the plain helm chart with nothing changed
+          - name: 'Default - no custom values'
+
+          # test the helm chart with postgresql subchart enabled
+          - name: PostgreSQL Enabled
+            helm_args: '--helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing12345"'
+
+          # test the helm chart with nginx container enabled
+          - name: Nginx Enabled
+            helm_args: '--helm-extra-set-args "--set=image.flavor=fpm --set=nginx.enabled=true"'
+
+          # test the helm chart with horizontal pod autoscaling enabled
+          - name: Horizontal Pod Autoscaling Enabled
+            helm_args: '--helm-extra-set-args "--set=hpa.enabled=true --set=hpa.minPods=1 --set=hpa.maxPods=3 --set=hpa.targetCPUUtilizationPercentage=75"'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,48 +112,15 @@ jobs:
         uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing (install ${{ matrix.test_cases.name }})
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} ${{ matrix.test_cases.helm_args }}
 
-  test-postgresql-database:
-    runs-on: ubuntu-22.04
-    needs: [changes, lint]
-    if: needs.changes.outputs.src != 'false'
+  summary:
+    runs-on: ubuntu-latest-low
+    needs: [changes, run-tests]
+    if: always()
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.14.4
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.10.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        id: install
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-            ct install --target-branch ${{ github.event.repository.default_branch }} \
-            --helm-extra-set-args "--set=postgresql.enabled=true --set=postgresql.global.postgresql.auth.password=testing123456 --set=internalDatabase.enabled=false --set=externalDatabase.enabled=True --set=externalDatabase.type=postgresql --set=externalDatabase.password=testing123456"
+      - name: Summary
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.run-tests.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
## Description of the change

- updates the test jobs to be generated from a `strategy.matrix`
- adds job to matrix to run a test of chart with `nginx.enabled=true` and `image.flavor=fpm` both set
- adds job to matrix to run a test of chart with `hpa.enabled=true` set

## Benefits

- New tests are easier to add :)

- Now if anyone would like to change a config file or other template that seems like it could affect users that use the `nginx.enabled` parameter, this PR will do the bare minimum testing for that.

## Possible drawbacks

None that I can think of, but I'm also open to feedback :)

## Applicable issues

Not sure if we have any issues related to this 🤔 This is just something we've talked about several times.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
