### PR TITLE
fix #508 by checking for `.Values.nextcloud.existingSecret.tokenKey`

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.5.1
+version: 5.5.2
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.existingSecret.smtpUsernameKey`                  | Name of the key that contains the SMTP username                                                     | `nil`                      |
 | `nextcloud.existingSecret.smtpPasswordKey`                  | Name of the key that contains the SMTP password                                                     | `nil`                      |
 | `nextcloud.existingSecret.smtpHostKey`                      | Name of the key that contains the SMTP hostname                                                     | `nil`                      |
+| `nextcloud.existingSecret.tokenKey`                         | Name of the key that contains the nextcloud metrics token                                           | `''`                       |
 | `nextcloud.update`                                          | Trigger update if custom command is used                                                            | `0`                        |
 | `nextcloud.containerPort`                                   | Customize container port when not running as root                                                   | `80`                       |
 | `nextcloud.trustedDomains`                                  | Optional space-separated list of trusted domains                                                    | `[]`                       |

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -40,12 +40,12 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           env:
-            {{- if .Values.metrics.token }}
+            {{- if or .Values.metrics.token .Values.nextcloud.existingSecret.tokenKey }}
             - name: NEXTCLOUD_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.nextcloud.existingSecret.secretName | default (include "nextcloud.fullname" .) }}
-                  key: {{ .Values.nextcloud.existingSecret.tokenKey }}
+                  key: {{ .Values.nextcloud.existingSecret.tokenKey | default "nextcloud-token" }}
             {{- else }}
             - name: NEXTCLOUD_USERNAME
               valueFrom:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -83,7 +83,7 @@ nextcloud:
     # secretName: nameofsecret
     usernameKey: nextcloud-username
     passwordKey: nextcloud-password
-    tokenKey: nextcloud-token
+    tokenKey: ""
     smtpUsernameKey: smtp-username
     smtpPasswordKey: smtp-password
     smtpHostKey: smtp-host


### PR DESCRIPTION
## Description of the change

Fix setting `NEXTCLOUD_AUTH_TOKEN` env var for metrics deployment by ensuring we check for `.Values.nextcloud.existingSecret.tokenKey`. Also sets `.Values.nextcloud.existingSecret.tokenKey` to default to `''` which shouldn't be a breaking change, considering it was broken before.

## Benefits

Now users can actually use the `nextcloud.existingSecret.tokenKey` feature.

## Possible drawbacks

users will need to remember to set `nextcloud.existingSecret.tokenKey`

## Applicable issues

- fixes #508 

## Additional information

Fix originally described here:
https://github.com/nextcloud/helm/issues/508#issuecomment-2249855493

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
