### PR TITLE
Add better liveness/readiness/startup probe docs that we can easily link to

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -20,6 +20,7 @@ helm install my-release nextcloud/nextcloud
     * [Object Storage as Primary Storage Configuration](#object-storage-as-primary-storage-configuration)
     * [Persistence Configurations](#persistence-configurations)
     * [Metrics Configurations](#metrics-configurations)
+    * [Probes Configurations](#probes-configurations)
 * [Cron jobs](#cron-jobs)
 * [Using the nextcloud docker image auto-configuration via env vars](#using-the-nextcloud-docker-image-auto-configuration-via-env-vars)
 * [Multiple config.php file](#multiple-configphp-file)
@@ -192,24 +193,6 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `rbac.serviceaccount.create`                                | Wether to create a serviceaccount or use an existing one (requires rbac)                            | `true`                     |
 | `rbac.serviceaccount.name`                                  | The name of the sevice account that the deployment will use (requires rbac)                         | `nextcloud-serviceaccount` |
 | `rbac.serviceaccount.annotations`                           | Serviceaccount annotations                                                                          | `{}`                       |
-| `livenessProbe.enabled`                                     | Turn on and off liveness probe                                                                      | `true`                     |
-| `livenessProbe.initialDelaySeconds`                         | Delay before liveness probe is initiated                                                            | `10`                       |
-| `livenessProbe.periodSeconds`                               | How often to perform the probe                                                                      | `10`                       |
-| `livenessProbe.timeoutSeconds`                              | When the probe times out                                                                            | `5`                        |
-| `livenessProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                          | `3`                        |
-| `livenessProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `readinessProbe.enabled`                                    | Turn on and off readiness probe                                                                     | `true`                     |
-| `readinessProbe.initialDelaySeconds`                        | Delay before readiness probe is initiated                                                           | `10`                       |
-| `readinessProbe.periodSeconds`                              | How often to perform the probe                                                                      | `10`                       |
-| `readinessProbe.timeoutSeconds`                             | When the probe times out                                                                            | `5`                        |
-| `readinessProbe.failureThreshold`                           | Minimum consecutive failures for the probe                                                          | `3`                        |
-| `readinessProbe.successThreshold`                           | Minimum consecutive successes for the probe                                                         | `1`                        |
-| `startupProbe.enabled`                                      | Turn on and off startup probe                                                                       | `false`                    |
-| `startupProbe.initialDelaySeconds`                          | Delay before readiness probe is initiated                                                           | `30`                       |
-| `startupProbe.periodSeconds`                                | How often to perform the probe                                                                      | `10`                       |
-| `startupProbe.timeoutSeconds`                               | When the probe times out                                                                            | `5`                        |
-| `startupProbe.failureThreshold`                             | Minimum consecutive failures for the probe                                                          | `30`                       |
-| `startupProbe.successThreshold`                             | Minimum consecutive successes for the probe                                                         | `1`                        |
 | `hpa.enabled`                                               | Boolean to create a HorizontalPodAutoscaler. If set to `true`, ignores `replicaCount`.              | `false`                    |
 | `hpa.cputhreshold`                                          | CPU threshold percent for the HorizontalPodAutoscale                                                | `60`                       |
 | `hpa.minPods`                                               | Min. pods for the Nextcloud HorizontalPodAutoscaler                                                 | `1`                        |
@@ -409,6 +392,36 @@ helm install --name my-release -f values.yaml nextcloud/nextcloud
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+
+### Probes Configurations
+
+The nextcloud deployment includes a series of different probes you can use to determine if a pod is ready or not. You can learn more in the [Configure Liveness, Readiness and Startup Probes Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+
+| Parameter                            | Description                                 | Default |
+|--------------------------------------|---------------------------------------------|---------|
+| `livenessProbe.enabled`              | Turn on and off liveness probe              | `true`  |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated    | `10`    |
+| `livenessProbe.periodSeconds`        | How often to perform the probe              | `10`    |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                    | `5`     |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe  | `3`     |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe | `1`     |
+| `readinessProbe.enabled`             | Turn on and off readiness probe             | `true`  |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated   | `10`    |
+| `readinessProbe.periodSeconds`       | How often to perform the probe              | `10`    |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                    | `5`     |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe  | `3`     |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe | `1`     |
+| `startupProbe.enabled`               | Turn on and off startup probe               | `false` |
+| `startupProbe.initialDelaySeconds`   | Delay before readiness probe is initiated   | `30`    |
+| `startupProbe.periodSeconds`         | How often to perform the probe              | `10`    |
+| `startupProbe.timeoutSeconds`        | When the probe times out                    | `5`     |
+| `startupProbe.failureThreshold`      | Minimum consecutive failures for the probe  | `30`    |
+| `startupProbe.successThreshold`      | Minimum consecutive successes for the probe | `1`     |
+
+> [!Note]
+> If you are getting errors on initialization (such as `Fatal error: require_once(): Failed opening required '/var/www/html/lib/versioncheck.php'`, but you can get other errors as well), a good first step is to try and enable the startupProbe and/or increase the `initialDelaySeconds` for the `livenessProbe` and `readinessProbe` to something much greater (consider using `120` seconds instead of `10`. This is an especially good idea if your cluster is running on older hardware, has a slow internet connection, or you're using a slower storage class, such as NFS that's running with older disks or a slow connection.
 
 ## Cron jobs
 


### PR DESCRIPTION
## Description of the change

Add a dedicated section for Liveness, Readiness, and Startup probes to the README.

## Benefits

We've discussed this a number of times in different issues over the years, but for various reasons, users sometimes need to adjust their probes. This gives us a dedicated link we can use to point our community members to as a good troubleshooting step :)

Also, tinier dedicated table that's easier to clean up.

## Possible drawbacks

New section in docs that could throw off other PRs? I'm willing to wait on mine to move others forward though 🙏

## Applicable issues

There's no one issue specifically, but it was mentioned in https://github.com/nextcloud/helm/issues/584 that I most recently noticed. Will try to add other issues here if/when I find them 🙏

Would have been nice to link here as well: #368

## Additional information

Open to feedback as always :)

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
