### PR TITLE
Don't require `nodePort` to template if none is specified

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.5.5
+version: 5.5.6
 appVersion: 29.0.6
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -32,8 +32,8 @@ spec:
       targetPort: {{ .Values.nextcloud.containerPort }}
       protocol: TCP
       name: http
-      {{- if (eq .Values.service.type "NodePort") }}
-      nodePort: {{ .Values.service.nodePort | default "" }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
       {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -500,7 +500,7 @@ service:
   type: ClusterIP
   port: 8080
   loadBalancerIP: ""
-  nodePort: nil
+  nodePort:
   annotations: {}
     ## Insert your annotations such as below
     # test/test: pumuckel


### PR DESCRIPTION
## Description of the change

The actual port that the `NodePort` type service uses can be automatically generated if no `nodeport` field is specified, as per the docs here:
https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport

## Benefits

We now use a `with` instead of an `if` to make the code a bit cleaner, instead of setting the `nodePort` to `""` which I think may also be confusing and/or not work.

## Possible drawbacks

none that I can think of, but always open to feedback :)

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #44

## Additional information

The actual value of `nil` in values.yaml has to change, otherwise, it interprets the `nil` as a string.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
