### PR TITLE
add `mariadb.global.defaultStorageClass` to values.yaml

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.5.0
+version: 5.5.1
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -238,8 +238,10 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `mariadb.image.registry`                                              | MariaDB image registry                                                            | `docker.io`            |
 | `mariadb.image.repository`                                            | MariaDB image repository                                                          | `bitnami/mariadb`      |
 | `mariadb.image.tag`                                                   | MariaDB image tag                                                                 | ``                     |
+| `mariadb.global.defaultStorageClass`                                  | MariaDB Global default StorageClass for Persistent Volume(s)                      | `''`                   |
 | `mariadb.primary.persistence.enabled`                                 | Whether or not to Use a PVC on MariaDB primary                                    | `false`                |
-| `mariadb.primary.persistence.existingClaim`                           | Use an existing PVC for MariaDB primary                                           | `nil`                  |
+| `mariadb.primary.persistence.storageClass`                            | MariaDB primary persistent volume storage Class                                   | `''`                   |
+| `mariadb.primary.persistence.existingClaim`                           | Use an existing PVC for MariaDB primary                                           | `''`                   |
 | `postgresql.enabled`                                                  | Whether to use the PostgreSQL chart                                               | `false`                |
 | `postgresql.image.registry`                                           | PostgreSQL image registry                                                         | `docker.io`            |
 | `postgresql.image.repository`                                         | PostgreSQL image repository                                                       | `bitnami/postgresql`   |

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -391,6 +391,11 @@ mariadb:
   # To use an ALREADY DEPLOYED mariadb database, set this to false and configure the externalDatabase parameters
   enabled: false
 
+  # see: https://github.com/bitnami/charts/tree/main/bitnami/mariadb#global-parameters
+  global:
+    # overwrites the primary.persistence.storageClass value
+    defaultStorageClass: ""
+
   auth:
     database: nextcloud
     username: nextcloud
@@ -408,8 +413,8 @@ mariadb:
     persistence:
       enabled: false
       # Use an existing Persistent Volume Claim (must be created ahead of time)
-      # existingClaim: ""
-      # storageClass: ""
+      existingClaim: ""
+      storageClass: ""
       accessMode: ReadWriteOnce
       size: 8Gi
 


### PR DESCRIPTION
## Description of the change

Add `mariadb.global.defaultStorageClass` to our values.yaml and clean up the README to also include `mariadb.primary.persistence.storageClass` and `mariadb.primary.persistence.existingClaim` as they'd be common parameters.

## Benefits

Less confusion about how to use the MariaDB subchart because it better reflects the bitnami helm chart.

## Possible drawbacks

none that I can think of, but always happy for feedback :)

## Applicable issues

- fixes #123

## Additional information

nope

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
