### PR TITLE
Add `metrics.securityContext` and `metrics.podSecurityContext`

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.4.0
+version: 5.5.0
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -79,7 +79,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.metrics.securityContext }}
           securityContext:
-            runAsUser: 1000
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.metrics.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -645,6 +645,21 @@ metrics:
       prometheus.io/port: "9205"
     labels: {}
 
+  # security context for the metrics CONTAINER in the pod
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: true
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+
+  # security context for the metrics POD
+  podSecurityContext: {}
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:


### PR DESCRIPTION
## Description of the change

Allow users to set the securityContext on both the metrics container and the pod.

## Benefits

More security is good :)

## Possible drawbacks

can't think of any, but happy to discuss

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- closes #558 as it's virtually the same PR, but with the changes requested in the review as the developer is too busy right now
- partially addresses #356 as it also covers some of this, but the developer is too busy right now

## Additional information

n/a

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
