### PR TITLE
Add missing S3 parameters

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.4.0
+version: 5.5.0
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -284,6 +284,13 @@ Here are all the values you can currently configure in this helm chart to config
 | `nextcloud.objectStore.s3.autoCreate`           | auto-create the S3 bucket                                             | `false`     |
 | `nextcloud.objectStore.s3.storageClass`         | S3 storage class to use                                               | `STANDARD`  |
 | `nextcloud.objectStore.s3.sse_c_key`            | S3 server side encryption key.                                        | `''`        |
+| `nextcloud.objectStore.s3.concurrency`          | S3 maximum number of concurrent multipart uploads.                    | `5`         |
+| `nextcloud.objectStore.s3.proxy`                | S3 proxy enabled or not.                                              | `false`     |
+| `nextcloud.objectStore.s3.timeout`              | S3 timeout in seconds.                                                | `15`        |
+| `nextcloud.objectStore.s3.uploadPartSize`       | S3 max upload size, in bytes.                                         | `524288000` |
+| `nextcloud.objectStore.s3.putSizeLimit`         | S3 max PUT size, in bytes.                                            | `104857600` |
+| `nextcloud.objectStore.s3.version`              | S3 version to use.                                                    | `'latest'`  |
+| `nextcloud.objectStore.s3.verify_bucket_exists` | S3 param to check if bucket already exists on startup.                | `true`      |
 | `nextcloud.objectStore.s3.existingSecret`       | Use an existing Kubernetes Secret to fetch auth credentials           | `''`        |
 | `nextcloud.objectStore.s3.secretKeys.host`      | if using s3.existingSecret, secret key to use for the host            | `''`        |
 | `nextcloud.objectStore.s3.secretKeys.accessKey` | if using s3.existingSecret, secret key to use for the accessKeyID     | `''`        |

--- a/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
@@ -20,13 +20,13 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
         // required for older protocol versions
         'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false',
-        'concurrency' => getenv('OBJECTSTORE_S3_CONCURRENCY') ?: 5,
-        'proxy' => getenv('OBJECTSTORE_S3_PROXY') ?: false,
-        'timeout' => getenv('OBJECTSTORE_S3_TIMEOUT') ?: 15,
-        'uploadPartSize' => getenv('OBJECTSTORE_S3_UPLOADPARTSIZE') ?: 524288000,
-        'putSizeLimit' => getenv('OBJECTSTORE_S3_PUTSIZELIMIT') ?: 104857600,
-        'version' => getenv('OBJECTSTORE_S3_VERSION') ?: "latest",
-        'verify_bucket_exists' => getenv('OBJECTSTORE_S3_VERIFY_BUCKET_EXISTS') ?: true
+        'concurrency' => getenv('OBJECTSTORE_S3_CONCURRENCY'),
+        'proxy' => getenv('OBJECTSTORE_S3_PROXY'),
+        'timeout' => getenv('OBJECTSTORE_S3_TIMEOUT'),
+        'uploadPartSize' => getenv('OBJECTSTORE_S3_UPLOADPARTSIZE'),
+        'putSizeLimit' => getenv('OBJECTSTORE_S3_PUTSIZELIMIT'),
+        'version' => getenv('OBJECTSTORE_S3_VERSION'),
+        'verify_bucket_exists' => getenv('OBJECTSTORE_S3_VERIFY_BUCKET_EXISTS')
       )
     )
   );

--- a/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
@@ -19,7 +19,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         // required for some non Amazon S3 implementations
         'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
         // required for older protocol versions
-        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false',
+        'concurrency' => getenv('OBJECTSTORE_S3_CONCURRENCY') ?: 5,
+        'proxy' => getenv('OBJECTSTORE_S3_PROXY') ?: false,
+        'timeout' => getenv('OBJECTSTORE_S3_TIMEOUT') ?: 15,
+        'uploadPartSize' => getenv('OBJECTSTORE_S3_UPLOADPARTSIZE') ?: 524288000,
+        'putSizeLimit' => getenv('OBJECTSTORE_S3_PUTSIZELIMIT') ?: 104857600,
+        'version' => getenv('OBJECTSTORE_S3_VERSION') ?: "latest",
+        'verify_bucket_exists' => getenv('OBJECTSTORE_S3_VERIFY_BUCKET_EXISTS') ?: true
       )
     )
   );

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -247,8 +247,24 @@ S3 as primary object store env vars
   value: {{ .Values.nextcloud.objectStore.s3.usePathStyle | quote }}
 {{- with .Values.nextcloud.objectStore.s3.legacyAuth }}
 - name: OBJECTSTORE_S3_LEGACYAUTH
-  value: {{ . }}
+  value: {{ . | quote }}
 {{- end }}
+- name: OBJECTSTORE_S3_CONCURRENCY
+  value: {{ .Values.nextcloud.objectStore.s3.concurrency | quote }}
+{{- with .Values.nextcloud.objectStore.s3.proxy }}
+- name: OBJECTSTORE_S3_PROXY
+  value: {{ . | quote }}
+{{- end }}
+- name: OBJECTSTORE_S3_TIMEOUT
+  value: {{ .Values.nextcloud.objectStore.s3.timeout | quote }}
+- name: OBJECTSTORE_S3_UPLOADPARTSIZE
+  value: {{ .Values.nextcloud.objectStore.s3.uploadPartSize | quote }}
+- name: OBJECTSTORE_S3_PUTSIZELIMIT
+  value: {{ .Values.nextcloud.objectStore.s3.putSizeLimit | quote }}
+- name: OBJECTSTORE_S3_VERSION
+  value: {{ .Values.nextcloud.objectStore.s3.version | quote }}
+- name: OBJECTSTORE_S3_VERIFY_BUCKET_EXISTS
+  value: {{ .Values.nextcloud.objectStore.s3.verify_bucket_exists | quote }}
 - name: OBJECTSTORE_S3_AUTOCREATE
   value: {{ .Values.nextcloud.objectStore.s3.autoCreate | quote }}
 - name: OBJECTSTORE_S3_REGION

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -141,6 +141,16 @@ nextcloud:
       storageClass: "STANDARD"
       # server side encryption key. learn more: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#s3-sse-c-encryption-support
       sse_c_key: ""
+      # defines the maximum number of concurrent multipart uploads
+      concurrency: 5
+      proxy: false
+      timeout: 15
+      uploadPartSize: 524288000
+      putSizeLimit: 104857600
+      version: "latest"
+      # Setting this to false after confirming the bucket has been created may provide a performance benefit,
+      # but may not be possible in multibucket scenarios.
+      verify_bucket_exists: true
       # use an existingSecret for S3 credentials. If set, we ignore the following under nextcloud.objectStore.s3
       # endpoint, accessKey, secretKey
       existingSecret: ""


### PR DESCRIPTION
## Description of the change

This adds the remaining variables that are due to eventually be added in the upstream https://github.com/nextcloud/docker/pull/2271. All of these parameters are documented [here](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3).

## Benefits

Now users will be able to set every single documented Nextcloud S3 parameter, even if it's not yet supported in the docker image upstream.

## Possible drawbacks

Some of these env vars are not yet merged in the docker container repo, which may cause some confusion, but shouldn't make a difference overall.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #612

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
