### PR TITLE
Feature: Add Collabora as a subchart #611

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add collabora-online https://collaboraonline.github.io/online
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
@@ -102,6 +103,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add collabora-online https://collaboraonline.github.io/online
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1

--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.5.0
-digest: sha256:4efc098feeb7f4486b7166f1c71b9c54bfee0797663a3339f379d397297303c7
-generated: "2024-06-03T09:51:56.321676+02:00"
+- name: collabora-online
+  repository: https://collaboraonline.github.io/online
+  version: 1.1.20
+digest: sha256:60224a47e840878016e971dedc426deeede6c98e1afd31e133f408d113dfa97e
+generated: "2024-08-23T09:26:14.290537755Z"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 5.5.2
+version: 5.6.0
 appVersion: 29.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -34,3 +34,8 @@ dependencies:
     version: 19.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
+  - name: collabora-online
+    version: 1.1.20
+    repository: https://collaboraonline.github.io/online
+    condition: collabora.enabled
+    alias: collabora

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -426,6 +426,37 @@ The nextcloud deployment includes a series of different probes you can use to de
 > [!Note]
 > If you are getting errors on initialization (such as `Fatal error: require_once(): Failed opening required '/var/www/html/lib/versioncheck.php'`, but you can get other errors as well), a good first step is to try and enable the startupProbe and/or increase the `initialDelaySeconds` for the `livenessProbe` and `readinessProbe` to something much greater (consider using `120` seconds instead of `10`. This is an especially good idea if your cluster is running on older hardware, has a slow internet connection, or you're using a slower storage class, such as NFS that's running with older disks or a slow connection.
 
+### Collabora Configuration
+
+This section provides options to enable and configure the Collabora Online server within your deployment. Please ensure to review the [Collabora Online Helm chart documentation](https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm/collabora-online) for additional details and recommended values.
+
+| Parameter                              | Description                                                                                      | Default                                                                                          |
+|----------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `collabora.enabled`                    | Enable or disable the Collabora Online integration                                               | `false`                                                                                          |
+| `collabora.autoscaling.enabled`        | Enable or disable autoscaling for the Collabora Online pods                                      | `false`                                                                                          |
+| `collabora.collabora.aliasgroups`      | List of HTTPS nextcloud domains if Collabora is behind a reverse proxy                           | `nil`                                                                                   |
+| `collabora.collabora.extra_params`     | Additional parameters for the Collabora Online service                                           | `nil`                                  |
+| `collabora.collabora.server_name`      | Specify the server name when the hostname is not directly reachable (e.g., behind a reverse proxy) | `nil`                                                                                          |
+| `collabora.existingSecret.enabled`     | Enable using existing secret for admin login credentials                                         | `false`                                                                                          |
+| `collabora.existingSecret.secretName`  | Name of the existing secret containing admin login credentials                                   | `""`                                                                                     |
+| `collabora.existingSecret.usernameKey` | Key in the secret for the admin username                                                         | `"username"`                                                                                     |
+| `collabora.existingSecret.passwordKey` | Key in the secret for the admin password                                                         | `"password"`                                                                                     |
+| `collabora.collabora.username`         | Admin username for Collabora Online                                                              | `admin`                                                                                        |
+| `collabora.collabora.password`         | Admin password for Collabora Online                                                              | `examplepass`                                                                                  |
+| `collabora.ingress.enabled`            | Enable or disable ingress for Collabora Online                                                   | `false`                                                                                          |
+| `collabora.ingress.className`          | Class name for the ingress controller                                                            | `""`                                                                                     |
+| `collabora.ingress.annotations`        | Annotations for the ingress resource                                                             | `{}`                                                                                     |
+| `collabora.ingress.hosts`              | List of hosts for the Collabora ingress                                                          | `[{"host": "chart-example.local", "paths": [{"path": "/", "pathType": "ImplementationSpecific"}]}]` |
+| `collabora.ingress.tls`                | TLS configuration for the Collabora ingress                                                      | `[]`                                                                                     |
+| `collabora.resources`                  | Resource requests and limits for the Collabora Online pods                                       | `{}`                                                                                     |
+> **Note**:
+>
+> You may need to uncomment `collabora.collabora.aliasgroups` and `collabora.collabora.extra_params`, depending on your setup. You may also need to set `collabora.collabora.server_name`. If left empty, it's derived from the request, so please set it if it doesn't work. 
+> 
+> If you have both Nextcloud and Collabora behind a reverse proxy with HTTPS, `collabora.collabora.aliasgroups` should match your Nextcloud domain and `collabora.collabora.server_name` (if needed) should match your Collabora domain.
+>
+> For more information, please check the [Collabora documentation](https://sdk.collaboraonline.com/docs/installation/index.html).
+
 ## Cron jobs
 
 To execute [background tasks](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html) by using system cron instead of default Ajax cron, set `cronjob.enabled` parameter to `true`. Background jobs are important for tasks that do not necessarily need user intervention, but still need to be executed frequently (cleaning up, sending some notifications, pulling RSS feeds, etc.).

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -472,6 +472,54 @@ redis:
     persistence:
       enabled: true
 
+##
+## Collabora chart configuration
+## for more options see https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm/collabora-online
+##
+collabora:
+  enabled: false
+
+  # please check collabora README.md first
+  autoscaling:
+    enabled: false
+
+  collabora:
+    ## HTTPS nextcloud domain, if needed
+    # aliasgroups:
+    #   - host: "https://nextcloud.domain:443"
+    # extra_params: --o:ssl.enable=false --o:ssl.termination=true
+
+    ## Specify server_name when the hostname is not reachable directly for example behind reverse-proxy
+    # server_name: collabora.domain
+
+    # setup admin login credentials
+    existingSecret:
+      enabled: false
+      secretName: ""
+      usernameKey: "username"
+      passwordKey: "password"
+    password: examplepass
+    username: admin
+  
+  # setup ingress
+  ingress:
+    enabled: false
+    className: ""
+    # please check collabora values.yaml for nginx/haproxy annotations examples
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: collabora-ingress-tls
+    #    hosts:
+    #      - collabora.domain
+
+  # see collabora helm README.md for recommended values
+  resources: {}
+
 
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -500,7 +500,6 @@ collabora:
       passwordKey: "password"
     password: examplepass
     username: admin
-  
   # setup ingress
   ingress:
     enabled: false


### PR DESCRIPTION
## Description of the change

- Add a dependency to the 1.1.20 collabora chart from their official repository
- Add the subchart config to values.yaml
- Add the configuration options documentation to README

## Benefits

- Install collabora as a subchart of nextcloud via helm

## Possible drawbacks

- People may try to enable it without knowing what is is and how to configure it (mainly `extra_params`, `server_name`, `aliasgroups` and `annotations`.

## Applicable issues

- fixes #611 

## Additional information

Tested on my local kubernetes cluster with a HTTPS nginx ingress. Nextcloud can communicate with Collabora. Not tested with HAProxy (though it is only a change in annotations specific to HAProxy).

## Checklist 

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Parameters are documented in the README.md
