### PR TITLE
fix s3 `secretKeys.sse_c_key` secret key checking typo; now `sse_c_key` is not required for using s3 with this chart

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.0.0
+version: 6.0.1
 appVersion: 30.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -301,7 +301,7 @@ S3 as primary object store env vars
 - name: OBJECTSTORE_S3_SECRET
   value: {{ .Values.nextcloud.objectStore.s3.secretKey | quote }}
 {{- end }}
-{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.bucket }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.sse_c_key }}
 - name: OBJECTSTORE_S3_SSE_C_KEY
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Description of the change

I did a copypasta typo where I was checking for the s3 bucket parameter instead of the sse c key parameter 🤦 This PR fixes that.

## Benefits

Now SSE C won't be required to use this chart with s3 as a primary object store.

## Possible drawbacks

none that come to mind, but happy to chat :)

## Applicable issues

- fixes #616

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
