### PR TITLE
add default of "" for externalDatabase.host; update README to be a little more clear

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.0.1
+version: 6.0.2
 appVersion: 30.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -220,7 +220,7 @@ If you choose to use one of the prepackaged Bitnami helm charts, you must config
 | `internalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
 | `externalDatabase.enabled`                                            | Whether to use external database                                                  | `false`                |
 | `externalDatabase.type`                                               | External database type: `mysql`, `postgresql`                                     | `mysql`                |
-| `externalDatabase.host`                                               | Host of the external database in form of `host:port`                              | `nil`                  |
+| `externalDatabase.host`                                               | Host of the external database in form of `host:port`. Example: `"myhost:1234"`    | `""`                   |
 | `externalDatabase.database`                                           | Name of the existing database                                                     | `nextcloud`            |
 | `externalDatabase.user`                                               | Existing username in the external db                                              | `nextcloud`            |
 | `externalDatabase.password`                                           | Password for the above username                                                   | `nil`                  |

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -360,8 +360,8 @@ externalDatabase:
   ## Supported database engines: mysql or postgresql
   type: mysql
 
-  ## Database host
-  host:
+  ## Database host. You can optionally include a colon delimited port like "myhost:1234"
+  host: ""
 
   ## Database user
   user: nextcloud


### PR DESCRIPTION
## Description of the change

Adds a default for `externalDatabase.host` to be `""` so it's clear the type taken, and also reminds people that they need to quote when using a `:` in a value in yaml. Also adds a bit more of a comment for that value and updates the README to reflect both changes.

## Benefits

Just resolves tiny bit of possible confusion around how to specify a database port.

## Possible drawbacks

none that I can think of

## Applicable issues

- fixes #632
- addresses https://github.com/nextcloud/helm/discussions/618

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
