### PR TITLE
Fix: quote `nextcloud.objectStore.s3.legacyAuth` value when rendering as env var

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.0.2
+version: 6.0.3
 appVersion: 30.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -247,7 +247,7 @@ S3 as primary object store env vars
   value: {{ .Values.nextcloud.objectStore.s3.usePathStyle | quote }}
 {{- with .Values.nextcloud.objectStore.s3.legacyAuth }}
 - name: OBJECTSTORE_S3_LEGACYAUTH
-  value: {{ . }}
+  value: {{ . | quote }}
 {{- end }}
 - name: OBJECTSTORE_S3_AUTOCREATE
   value: {{ .Values.nextcloud.objectStore.s3.autoCreate | quote }}


### PR DESCRIPTION
## Description of the change

This quotes the `nextcloud.objectStore.s3.legacyAuth` value when rendering it as an env var in `_helpers.tpl`. I think that's why it wasn't working before.

## Benefits

Without this fix, setting the value to true doesn't work.

## Possible drawbacks

We could also just have it be this to be more explicit, since the `with` will ignore a value of `false` anyway:

```go
{{- with .Values.nextcloud.objectStore.s3.legacyAuth }}
- name: OBJECTSTORE_S3_LEGACYAUTH
  value: "true"
{{- end }}
```

Either should solve the issue 🤷 

## Applicable issues

- fixes #637

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
