### PR TITLE
feat(nginx): add ipFamilies option for IPv4 and IPv6

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.0.3
+version: 6.1.0
 appVersion: 30.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -161,6 +161,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nginx.image.pullPolicy`                                    | nginx Image pull policy                                                                             | `IfNotPresent`             |
 | `nginx.image.pullPolicy`                                    | nginx Image pull policy                                                                             | `IfNotPresent`             |
 | `nginx.containerPort`                                       | Customize container port e.g. when not running as root                                              | `IfNotPresent`             |
+| `nginx.ipFamilies`                                          | Customize container to listen on IPv4, IPv6 or both                                                 | `["IPv4"]`                 |
 | `nginx.config.default`                                      | Whether to use nextcloud's recommended nginx config                                                 | `true`                     |
 | `nginx.config.custom`                                       | Specify a custom config for nginx                                                                   | `{}`                       |
 | `nginx.resources`                                           | nginx resources                                                                                     | `{}`                       |

--- a/charts/nextcloud/files/nginx.config.tpl
+++ b/charts/nextcloud/files/nginx.config.tpl
@@ -3,7 +3,16 @@ upstream php-handler {
 }
 
 server {
+    {{- if and (has "IPv4" .Values.nginx.ipFamilies) (has "IPv6" .Values.nginx.ipFamilies) }}
+    # Both IPv4 and IPv6 are enabled
+    listen [::]:{{ .Values.nginx.containerPort }} ipv6only=off;
+    {{- else if and (not (has "IPv4" .Values.nginx.ipFamilies)) (has "IPv6" .Values.nginx.ipFamilies) }}
+    # Only IPv6 is enabled
+    listen [::]:{{ .Values.nginx.containerPort }};
+    {{- else }}
+    # Default, IPv4 only
     listen {{ .Values.nginx.containerPort }};
+    {{- end }}
 
     # HSTS settings
     # WARNING: Only add the preload option once you read about
@@ -48,7 +57,7 @@ server {
     include mime.types;
     types {
         text/javascript js mjs;
-    }        
+    }
 
     # Path to the root of your installation
     root /var/www/html;

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -324,7 +324,10 @@ nginx:
     pullPolicy: IfNotPresent
 
   containerPort: 80
-
+  # This configures nginx to listen on either IPv4, IPv6 or both
+  ipFamilies:
+    - IPv4
+    # - IPv6
   config:
     # This generates the default nginx config as per the nextcloud documentation
     default: true


### PR DESCRIPTION
## Description of the change

Add an option to configure the listening IP address for the nginx container.

## Benefits

This will allow setting the IP to a value like "[::]" for IPv6 deployments. The current generated configs force the address to 0.0.0.0

## Possible drawbacks

None that I can think of. The default value is 0.0.0.0 which is equivalent to the configuration generated by the chart at the moment.

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #636

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] (optional) Parameters are documented in the README.md
