### PR TITLE
chore: upgrade postgresql to 17.0 (chart 16.0.0)

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.0
+  version: 16.0.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.5.0
-digest: sha256:4efc098feeb7f4486b7166f1c71b9c54bfee0797663a3339f379d397297303c7
-generated: "2024-06-03T09:51:56.321676+02:00"
+digest: sha256:080beda58fb6b2ec9735f1f1c47419bf9da237008b6ce7c13e4c3f1bb3af90bc
+generated: "2024-10-03T11:54:49.101000727+02:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: jeff@billimek.com
 dependencies:
   - name: postgresql
-    version: 15.5.0
+    version: 16.0.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: mariadb


### PR DESCRIPTION
## Description of the change

Update postgresql to 17.0 (chart version is 16.0)
close #641 

## Benefits

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).

