### PR TITLE
Update README.md - update bus error info under huge pages documentation

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -548,8 +548,8 @@ ingress:
 
 ## Hugepages
 
-If your node has hugepages enabled, but you do not map any into the container, it could fail to start with a bus error in Apache. This is due
-to Apache attempting to memory map a file and use hugepages. The fix is to either disable huge pages on the node or map hugepages into the container:
+If your node has hugepages enabled, but you do not map any into the container, it could fail to start with a bus error. This is due
+to your webserver attempting to memory map a file and use hugepages. This can happen in both the apache and fpm images. The fix is to either disable huge pages on the node or map hugepages into the container:
 
 ```yaml
 nextcloud:


### PR DESCRIPTION
## Description of the change

Update docs a bit more around huge pages to mention other web servers outside of apache.

## Benefits

Previously, the docs were focused on apache, leading some to think that this couldn't affect fpm. Thanks to the good users of #644, we now know it can affect all images, and update the docs to be more clear.

## Possible drawbacks

unsure, but open to chatting as always :)

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #644

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
