### PR TITLE
docs: Add postgreSqlInitContainer values to README

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.extraVolumeMounts`                               | specify additional volume mounts for the NextCloud pod                                              | `{}`                       |
 | `nextcloud.securityContext`                                 | Optional security context for the NextCloud container                                               | `nil`                      |
 | `nextcloud.podSecurityContext`                              | Optional security context for the NextCloud pod (applies to all containers in the pod)              | `nil`                      |
+| `nextcloud.postgreSqlInitContainer.securityContext`         | Set postgresql initContainer securityContext parameters.                                            | `{}`                       |
 | `nginx.enabled`                                             | Enable nginx (requires you use php-fpm image)                                                       | `false`                    |
 | `nginx.image.repository`                                    | nginx Image name, e.g. use `nginxinc/nginx-unprivileged` for rootless container                     | `nginx`                    |
 | `nginx.image.tag`                                           | nginx Image tag                                                                                     | `alpine`                   |


### PR DESCRIPTION
## Description of the change

This change documents the value field `nextcloud.postgreSqlInitContainer.securityContext` in the README.

## Benefits

The value gets increased visibility to users, so they know it exists.

## Possible drawbacks

More docs to maintain.

## Applicable issues

- fixes #645

## Additional information

Manually maintaining such a large table of values seems very tedious and error prone. I would recommend looking into a tool to automate it, for example [Bitnami's README generator](https://github.com/bitnami/readme-generator-for-helm).

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
