### PR TITLE
wip: reuse resource definition to run db-isalive init containers

### DIFF
--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -314,6 +314,8 @@ spec:
             - "sh"
             - "-c"
             - {{ printf "until mysql --host=%s-mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
@@ -333,6 +335,8 @@ spec:
             - "sh"
             - "-c"
             - "until pg_isready -h ${POSTGRES_HOST} -U ${POSTGRES_USER} ; do sleep 2 ; done"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- end }}{{/* end-if any database-initContainer */}}
       {{- end }}{{/* end-if any initContainer */}}
       {{- with .Values.affinity }}


### PR DESCRIPTION
## Description of the change

- reuse resource definition to run db-isalive init containers

## Benefits

- make the helm chart work in environments that require resource definitions

## Possible drawbacks

- nothing I can think of 

## Applicable issues


## Additional information



## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
