### PR TITLE
Enable setting initContainers' resources

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.2.4
+version: 6.3.0
 appVersion: 30.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -155,6 +155,10 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.extraInitContainers`                             | specify additional init containers                                                                  | `[]`                       |
 | `nextcloud.extraVolumes`                                    | specify additional volumes for the NextCloud pod                                                    | `{}`                       |
 | `nextcloud.extraVolumeMounts`                               | specify additional volume mounts for the NextCloud pod                                              | `{}`                       |
+| `nextcloud.mariaDbInitContainer.resources`                  | set the `resources` field of the MariaDB init container in the Nextcloud Pod.                       | `{}`                       |
+| `nextcloud.mariaDbInitContainer.securityContext`            | set the `securityContext` field of the MariaDB init container in the Nextcloud Pod.                 | `{}`                       |
+| `nextcloud.postgreSqlInitContainer.resources`               | set the `resources` field of the PostgreSQL init container in the Nextcloud Pod.                    | `{}`                       |
+| `nextcloud.postgreSqlInitContainer.securityContext`         | set the `securityContext` field of the PostgreSQL init container in the Nextcloud Pod.              | `{}`                       |
 | `nextcloud.securityContext`                                 | Optional security context for the NextCloud container                                               | `nil`                      |
 | `nextcloud.podSecurityContext`                              | Optional security context for the NextCloud pod (applies to all containers in the pod)              | `nil`                      |
 | `nextcloud.postgreSqlInitContainer.securityContext`         | Set postgresql initContainer securityContext parameters.                                            | `{}`                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -295,9 +295,11 @@ spec:
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
           image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
-          {{- with .Values.nextcloud.mariaDbInitContainer.securityContext }}
+          {{- with .Values.nextcloud.mariaDbInitContainer }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .securityContext | nindent 12 }}
           {{- end }}
           env:
             - name: MYSQL_USER
@@ -317,9 +319,11 @@ spec:
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
           image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-          {{- with .Values.nextcloud.postgreSqlInitContainer.securityContext }}
+          {{- with .Values.nextcloud.postgreSqlInitContainer }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .securityContext | nindent 12 }}
           {{- end }}
           env:
             - name: POSTGRES_USER

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -305,11 +305,13 @@ nextcloud:
 
   # Settings for the MariaDB init container
   mariaDbInitContainer:
+    resources: {}
     # Set mariadb initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
     securityContext: {}
 
   # Settings for the PostgreSQL init container
   postgreSqlInitContainer:
+    resources: {}
     # Set postgresql initContainer securityContext parameters. For example, you may need to define runAsNonRoot directive
     securityContext: {}
 


### PR DESCRIPTION
## Description of the change

This change adds values that lets users set the resources (requests/limits) for the initContainers in the nextcloud pod.

I did also did a small refactoring to keep the code simple and also added the missing `securityContext` values to the README.

## Benefits

By setting resource requests for the `initContainers`, many different failure modes can be avoided.

## Possible drawbacks

Increased code complexity, maybe.

## Applicable issues

- fixes #661 

## Additional information

See #661

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
