### PR TITLE
Update release.yaml - add collabora online helm repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add collabora https://collaboraonline.github.io/online/
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0


### PR DESCRIPTION
## Description of the change

Add the collabora online helm repo to the release process

## Benefits

Now we can release with collabora online.

## Possible drawbacks

Not sure if it should be named collabora or collabora-online

## Applicable issues

Fixes https://github.com/nextcloud/helm/pull/623#issuecomment-2544026430

## Additional information

none that I can think of, but always happy to chat :)

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
