### PR TITLE
feat(nextcloud): Add support for AWS session token key

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.6.3
+version: 6.6.4
 # renovate: image=docker.io/library/nextcloud
 appVersion: 30.0.5
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -317,39 +317,40 @@ Read more in the official [docs](https://docs.nextcloud.com/server/latest/admin_
 Here are all the values you can currently configure in this helm chart to configure an Object Store as your Primary Storage.
 
 
-| Parameter                                       | Description                                                           | Default     |
-|-------------------------------------------------|-----------------------------------------------------------------------|-------------|
-| `nextcloud.objectStore.s3.enabled`              | enable configuring S3 as a primary object store                       | `false`     |
-| `nextcloud.objectStore.s3.accessKey`            | accessKeyID for authing to S3, ignored if using existingSecret        | `''`        |
-| `nextcloud.objectStore.s3.secretKey`            | secretAccessKey for authing to S3, ignored if using existingSecret    | `''`        |
-| `nextcloud.objectStore.s3.legacyAuth`           | use legacy authentication for S3                                      | `false`     |
-| `nextcloud.objectStore.s3.host`                 | endpoint URL to connect to. Only required if not using AWS            | `''`        |
-| `nextcloud.objectStore.s3.ssl`                  | Use TLS connection when connecting to S3                              | `true`      |
-| `nextcloud.objectStore.s3.port`                 | Port for S3 host to use                                               | `443`       |
-| `nextcloud.objectStore.s3.region`               | region to look for bucket in on the S3 host                           | `eu-west-1` |
-| `nextcloud.objectStore.s3.bucket`               | bucket on the S3 host                                                 | `''`        |
-| `nextcloud.objectStore.s3.prefix`               | optional object prefix                                                | `''`        |
-| `nextcloud.objectStore.s3.usePathStyle`         | set to true if you are not using DNS for your buckets                 | `false`     |
-| `nextcloud.objectStore.s3.autoCreate`           | auto-create the S3 bucket                                             | `false`     |
-| `nextcloud.objectStore.s3.storageClass`         | S3 storage class to use                                               | `STANDARD`  |
-| `nextcloud.objectStore.s3.sse_c_key`            | S3 server side encryption key.                                        | `''`        |
-| `nextcloud.objectStore.s3.existingSecret`       | Use an existing Kubernetes Secret to fetch auth credentials           | `''`        |
-| `nextcloud.objectStore.s3.secretKeys.host`      | if using s3.existingSecret, secret key to use for the host            | `''`        |
-| `nextcloud.objectStore.s3.secretKeys.accessKey` | if using s3.existingSecret, secret key to use for the accessKeyID     | `''`        |
-| `nextcloud.objectStore.s3.secretKeys.secretKey` | if using s3.existingSecret, secret key to use for the secretAccessKey | `''`        |
-| `nextcloud.objectStore.s3.secretKeys.bucket`    | if using s3.existingSecret, secret key to use for the bucket          | `''`        |
-| `nextcloud.objectStore.s3.secretKeys.sse_c_key` | if using s3.existingSecret, secret key to use for the sse_c_key       | `''`        |
-| `nextcloud.objectStore.swift.enabled`           | enable configuring Openstack Swift as a primary object store          | `false`     |
-| `nextcloud.objectStore.swift.user.domain`       | optional: swift user domain                                           | `'Default'` |
-| `nextcloud.objectStore.swift.user.name`         | Swift username                                                        | `''`        |
-| `nextcloud.objectStore.swift.user.password`     | Swift user password                                                   | `''`        |
-| `nextcloud.objectStore.swift.project.name`      | Swift project name                                                    | `''`        |
-| `nextcloud.objectStore.swift.project.domain`    | optional: swift project domain                                        | `'Default'` |
-| `nextcloud.objectStore.swift.url`               | Swift Identity / Keystone endpoint                                    | `''`        |
-| `nextcloud.objectStore.swift.region`            | Swift region                                                          | `''`        |
-| `nextcloud.objectStore.swift.service`           | Optional: service name, used on some swift implementations            | `'swift'`   |
-| `nextcloud.objectStore.swift.container`         | Swift container to store the data in                                  | `''`        |
-| `nextcloud.objectStore.swift.autoCreate`        | Autocreate the Swift container                                        | `false`     |
+| Parameter                                             | Description                                                           | Default     |
+|-------------------------------------------------------|-----------------------------------------------------------------------|-------------|
+| `nextcloud.objectStore.s3.enabled`                    | enable configuring S3 as a primary object store                       | `false`     |
+| `nextcloud.objectStore.s3.accessKey`                  | accessKeyID for authing to S3, ignored if using existingSecret        | `''`        |
+| `nextcloud.objectStore.s3.secretKey`                  | secretAccessKey for authing to S3, ignored if using existingSecret    | `''`        |
+| `nextcloud.objectStore.s3.legacyAuth`                 | use legacy authentication for S3                                      | `false`     |
+| `nextcloud.objectStore.s3.host`                       | endpoint URL to connect to. Only required if not using AWS            | `''`        |
+| `nextcloud.objectStore.s3.ssl`                        | Use TLS connection when connecting to S3                              | `true`      |
+| `nextcloud.objectStore.s3.port`                       | Port for S3 host to use                                               | `443`       |
+| `nextcloud.objectStore.s3.region`                     | region to look for bucket in on the S3 host                           | `eu-west-1` |
+| `nextcloud.objectStore.s3.bucket`                     | bucket on the S3 host                                                 | `''`        |
+| `nextcloud.objectStore.s3.prefix`                     | optional object prefix                                                | `''`        |
+| `nextcloud.objectStore.s3.usePathStyle`               | set to true if you are not using DNS for your buckets                 | `false`     |
+| `nextcloud.objectStore.s3.autoCreate`                 | auto-create the S3 bucket                                             | `false`     |
+| `nextcloud.objectStore.s3.storageClass`               | S3 storage class to use                                               | `STANDARD`  |
+| `nextcloud.objectStore.s3.sse_c_key`                  | S3 server side encryption key.                                        | `''`        |
+| `nextcloud.objectStore.s3.existingSecret`             | Use an existing Kubernetes Secret to fetch auth credentials           | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.host`            | if using s3.existingSecret, secret key to use for the host            | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.accessKey`       | if using s3.existingSecret, secret key to use for the accessKeyID     | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.secretKey`       | if using s3.existingSecret, secret key to use for the secretAccessKey | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.sessionTokenKey` | if using s3.existingSecret, secret key to use for the sessionTokenKey | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.bucket`          | if using s3.existingSecret, secret key to use for the bucket          | `''`        |
+| `nextcloud.objectStore.s3.secretKeys.sse_c_key`       | if using s3.existingSecret, secret key to use for the sse_c_key       | `''`        |
+| `nextcloud.objectStore.swift.enabled`                 | enable configuring Openstack Swift as a primary object store          | `false`     |
+| `nextcloud.objectStore.swift.user.domain`             | optional: swift user domain                                           | `'Default'` |
+| `nextcloud.objectStore.swift.user.name`               | Swift username                                                        | `''`        |
+| `nextcloud.objectStore.swift.user.password`           | Swift user password                                                   | `''`        |
+| `nextcloud.objectStore.swift.project.name`            | Swift project name                                                    | `''`        |
+| `nextcloud.objectStore.swift.project.domain`          | optional: swift project domain                                        | `'Default'` |
+| `nextcloud.objectStore.swift.url`                     | Swift Identity / Keystone endpoint                                    | `''`        |
+| `nextcloud.objectStore.swift.region`                  | Swift region                                                          | `''`        |
+| `nextcloud.objectStore.swift.service`                 | Optional: service name, used on some swift implementations            | `'swift'`   |
+| `nextcloud.objectStore.swift.container`               | Swift container to store the data in                                  | `''`        |
+| `nextcloud.objectStore.swift.autoCreate`              | Autocreate the Swift container                                        | `false`     |
 
 
 

--- a/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
+++ b/charts/nextcloud/files/defaultConfigs/s3.config.php.tpl
@@ -40,6 +40,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
     $CONFIG['objectstore']['arguments']['secret'] = '';
   }
 
+  if (getenv('OBJECTSTORE_S3_SESSION_TOKEN_FILE')) {
+    $CONFIG['objectstore']['arguments']['session_token'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_SESSION_TOKEN_FILE')));
+  } elseif (getenv('OBJECTSTORE_S3_SESSION_TOKEN')) {
+    $CONFIG['objectstore']['arguments']['session_token'] = getenv('OBJECTSTORE_S3_SESSION_TOKEN');
+  } else {
+    $CONFIG['objectstore']['arguments']['session_token'] = '';
+  }
+
   if (getenv('OBJECTSTORE_S3_SSE_C_KEY_FILE')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_SSE_C_KEY_FILE')));
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -301,6 +301,13 @@ S3 as primary object store env vars
 - name: OBJECTSTORE_S3_SECRET
   value: {{ .Values.nextcloud.objectStore.s3.secretKey | quote }}
 {{- end }}
+{{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.sessionTokenKey }}
+- name: OBJECTSTORE_S3_SESSION_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.nextcloud.objectStore.s3.existingSecret }}
+      key: {{ .Values.nextcloud.objectStore.s3.secretKeys.sessionTokenKey }}
+{{- end }}
 {{- if and .Values.nextcloud.objectStore.s3.existingSecret .Values.nextcloud.objectStore.s3.secretKeys.sse_c_key }}
 - name: OBJECTSTORE_S3_SSE_C_KEY
   valueFrom:

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -151,6 +151,8 @@ nextcloud:
         accessKey: ""
         # key in nextcloud.objectStore.s3.existingSecret to use for s3 secretAccessKey
         secretKey: ""
+        # key in nextcloud.objectStore.s3.existingSecret to use for the s3 sessionToken
+        sessionTokenKey: ""
         # key in nextcloud.objectStore.s3.existingSecret to use for the s3 bucket
         bucket: ""
         # key in nextcloud.objectStore.s3.existingSecret to use for the s3 sse_c_key


### PR DESCRIPTION
## Description of the change

- Introduced a new configuration option for AWS Credentials to use a Session Token.
- Updated template and values to enable usage of the new key

## Benefits

- Support using temporal AWS Credentials (e.g. STS assumed role)

## Possible drawbacks

- None

## Applicable issues


<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- resolves #690
- related:
  * server [#50702](https://github.com/nextcloud/server/pull/50702)
  * docker [#2364](https://github.com/nextcloud/docker/pull/2364)

## Additional information

- As you might notice, the session token is only referenced within an existing secret config, the nature of such session 
tokens comes from temporal credentials, more likely secrets auto-generated from sts assume role, etc. Therefore 
it only makes sense to reference it from an "existing secret"

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
