### PR TITLE
Migrate the cron container from sidecar to K8s CronJob

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.6.6
+version: 6.6.7
 # renovate: image=docker.io/library/nextcloud
 appVersion: 30.0.6
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -1,0 +1,161 @@
+---
+{{- if .Values.cronjob.enabled }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: app
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: app
+        {{- if .Values.redis.enabled }}
+        {{ template "nextcloud.redis.fullname" . }}-client: "true"
+        {{- end }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        nextcloud-config-hash: {{ print (toJson .Values.nextcloud.defaultConfigs) "-" (toJson .Values.nextcloud.configs) | sha256sum }}
+        php-config-hash: {{ toJson .Values.nextcloud.phpConfigs | sha256sum }}
+        {{- if .Values.nginx.enabled }}
+        nginx-config-hash: {{ print .Values.nginx.config.default "-" .Values.nginx.config.custom | sha256sum }}
+        {{- end }}
+        hooks-hash: {{ toYaml .Values.nextcloud.hooks | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+            helm.sh/chart: {{ include "nextcloud.chart" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+            app.kubernetes.io/component: app
+        spec:
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- range . }}
+            - name: {{ . }}
+            {{- end}}
+          {{- end }}
+          containers:
+          - name: {{ .Chart.Name }}-cron
+            image: {{ include "nextcloud.image" . }}
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command:
+              - php
+              - -f
+              - /var/www/html/cron.php
+            {{- with .Values.cronjob.lifecycle }}
+            lifecycle:
+              {{- with .postStartCommand }}
+              postStart:
+                exec:
+                  command:
+                    {{- toYaml . | nindent 20 }}
+              {{- end }}
+              {{- with .preStopCommand }}
+              preStop:
+                exec:
+                  command:
+                    {{- toYaml . | nindent 20 }}
+              {{- end }}
+            {{- end }}
+            env:
+              {{- include "nextcloud.env" . | nindent 14 }}
+            resources:
+              {{- toYaml .Values.cronjob.resources | nindent 14 }}
+            {{- with .Values.cronjob.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            volumeMounts:
+              {{- include "nextcloud.volumeMounts" . | trim | nindent 14 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+            - name: nextcloud-main
+              {{- if .Values.persistence.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud{{- end }}
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+            {{- if and .Values.persistence.nextcloudData.enabled .Values.persistence.enabled }}
+            - name: nextcloud-data
+              persistentVolumeClaim:
+                claimName: {{ if .Values.persistence.nextcloudData.existingClaim }}{{ .Values.persistence.nextcloudData.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud-data{{- end }}
+            {{- end }}
+            {{- if .Values.nextcloud.configs }}
+            - name: nextcloud-config
+              configMap:
+                name: {{ template "nextcloud.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.nextcloud.phpConfigs }}
+            - name: nextcloud-phpconfig
+              configMap:
+                name: {{ template "nextcloud.fullname" . }}-phpconfig
+            {{- end }}
+            {{- if .Values.nginx.enabled }}
+            - name: nextcloud-nginx-config
+              configMap:
+                name: {{ template "nextcloud.fullname" . }}-nginxconfig
+            {{- end }}
+            {{- if not (values .Values.nextcloud.hooks | compact | empty) }}
+            - name: nextcloud-hooks
+              configMap:
+                name: {{ template "nextcloud.fullname" . }}-hooks
+                defaultMode: 0o755
+            {{- end }}
+            {{- with .Values.nextcloud.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.nextcloud.podSecurityContext }}
+            {{- toYaml . | nindent 12 }}
+            {{- else }}
+            {{- if .Values.nginx.enabled }}
+            # Will mount configuration files as www-data (id: 82) for nextcloud
+            fsGroup: 82
+            {{- else }}
+            # Will mount configuration files as www-data (id: 33) for nextcloud
+            fsGroup: 33
+            {{- end }}
+            {{- end }}{{/* end-with podSecurityContext */}}
+          restartPolicy: OnFailure
+          {{- if .Values.rbac.enabled }}
+          serviceAccountName: {{ .Values.rbac.serviceaccount.name }}
+          {{- end }}
+          {{- with .Values.dnsConfig }}
+          dnsConfig:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}{{/* end-if cronjob.enabled */}}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -248,38 +248,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- end }}{{/* end-if nginx.enabled */}}
-        {{- if .Values.cronjob.enabled }}
-        - name: {{ .Chart.Name }}-cron
-          image: {{ include "nextcloud.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /cron.sh
-          {{- with .Values.cronjob.lifecycle }}
-          lifecycle:
-            {{- with .postStartCommand }}
-            postStart:
-              exec:
-                command:
-                  {{- toYaml . | nindent 18 }}
-            {{- end }}
-            {{- with .preStopCommand }}
-            preStop:
-              exec:
-                command:
-                  {{- toYaml . | nindent 18 }}
-            {{- end }}
-          {{- end }}
-          env:
-            {{- include "nextcloud.env" . | nindent 12 }}
-          resources:
-            {{- toYaml .Values.cronjob.resources | nindent 12 }}
-          {{- with .Values.cronjob.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            {{- include "nextcloud.volumeMounts" . | trim | nindent 12 }}
-        {{- end }}{{/* end-if cronjob.enabled */}}
         {{- with .Values.nextcloud.extraSidecarContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Description of the change

With this change we no longer deploy a sidecar container to execute the cronjob, instead we deploy a Kubernetes CronJob object.

## Benefits

-  For me this has the major advantage that the CronJob can run as user www-data (uid 33) and execute the php command directly whereas crond in the sidecar has to run as root since otherwise the impersonation of user www-data fails (`crond: can't set groups: Operation not permitted`).
- History of failed and successful executions
- Apart from that I think that is also more robust if the container fails for some reason.

## Possible drawbacks

None obvious to me.

## Applicable issues

- fixes #577 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
