### PR TITLE
Make command of cronjob container configurable

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.6.6
+version: 6.6.7
 # renovate: image=docker.io/library/nextcloud
 appVersion: 30.0.6
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -190,6 +190,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `redis.global.storageClass`                                 | PVC Storage Class  for both Redis&reg; master and replica Persistent Volumes                        | `''`                       |
 | `redis.master.persistence.enabled`                          | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                        | `true`                     |
 | `redis.replica.persistence.enabled`                         | Enable persistence on Redis&reg; replica nodes using Persistent Volume Claims                       | `true`                     |
+| `cronjob.command`                                           | The command the cronjob container executes                                                          | `/cron.sh`                 |
 | `cronjob.enabled`                                           | Whether to enable/disable cron jobs sidecar                                                         | `false`                    |
 | `cronjob.lifecycle.postStartCommand`                        | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                        | `nil`                      |
 | `cronjob.lifecycle.preStopCommand`                          | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                          | `nil`                      |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -253,7 +253,7 @@ spec:
           image: {{ include "nextcloud.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /cron.sh
+            {{- toYaml .Values.cronjob.command | nindent 12 }}
           {{- with .Values.cronjob.lifecycle }}
           lifecycle:
             {{- with .postStartCommand }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -579,6 +579,10 @@ cronjob:
   #   runAsNonRoot: true
   #   readOnlyRootFilesystem: true
 
+  # The command the cronjob container executes.
+  command:
+  - /cron.sh
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## Description of the change

This allows to run it without root permissions by using a while-true-script over cron (cron needs root permissions for the impersonation).

## Benefits

* Improved security when not running as root.

## Possible drawbacks

* None as the default is not changed

## Applicable issues

- None found

## Additional information

I used `helm template` before and after my change and there was no difference.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
