### PR TITLE
Fix #714: large file upload tuning as configuration

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 7.0.0
+version: 7.0.1
 # renovate: image=docker.io/library/nextcloud
 appVersion: 31.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/files/nginx.config.tpl
+++ b/charts/nextcloud/files/nginx.config.tpl
@@ -26,9 +26,7 @@ server {
     {{- end }}
     {{- end }}
 
-    # set max upload size
-    client_max_body_size 10G;
-    fastcgi_buffers 64 4K;
+    {{- .Values.nginx.config.serverBlockCustom | nindent 4 }}
 
     # Enable gzip but do not remove ETag headers
     gzip on;

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -353,6 +353,13 @@ nginx:
       "X-Robots-Tag": "noindex, nofollow"
       "X-XSS-Protection": "1; mode=block"
 
+    # Added in server block of default config.
+    serverBlockCustom: |
+      # set max upload size
+      client_max_body_size 10G;
+      fastcgi_buffers 64 4K;
+      fastcgi_read_timeout 3600s;
+
     custom:
     # custom: |-
     #     worker_processes  1;..


### PR DESCRIPTION
## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Fix https://github.com/nextcloud/helm/issues/714

## Benefits

<!-- What benefits will be realized by the code change? -->

Can now upload large file. And if the default values are not enough, can override them in `values.yaml`.

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
