### PR TITLE
feat(whiteboard): Add optional whiteboard backend Deployment

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 6.6.9
+version: 6.7.0
 # renovate: image=docker.io/library/nextcloud
 appVersion: 30.0.6
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -538,15 +538,15 @@ We include an optional external preview provider from [h2non/imaginary](https://
 |----------------------------------------|-----------------------------------------------------------------------------------------|-------------------|
 | `imaginary.enabled`                    | Start Imaginary                                                                         | `false`           |
 | `imaginary.replicaCount`               | Number of imaginary pod replicas to deploy                                              | `1`               |
-| `imaginary.image.registry`             | Imaginary image name                                                                    | `docker.io`       |
-| `imaginary.image.repository`           | Imaginary image name                                                                    | `h2non/imaginary` |
+| `imaginary.image.registry`             | Imaginary image registry                                                                | `docker.io`       |
+| `imaginary.image.repository`           | Imaginary image repository                                                              | `h2non/imaginary` |
 | `imaginary.image.tag`                  | Imaginary image tag                                                                     | `1.2.4`           |
 | `imaginary.image.pullPolicy`           | Imaginary image pull policy                                                             | `IfNotPresent`    |
 | `imaginary.image.pullSecrets`          | Imaginary image pull secrets                                                            | `nil`             |
 | `imaginary.podAnnotations`             | Additional annotations for imaginary                                                    | `{}`              |
 | `imaginary.podLabels`                  | Additional labels for imaginary                                                         | `{}`              |
-| `imaginary.nodeSelector`               | Imaginary pod nodeSelector                                                                | `{}`              |
-| `imaginary.tolerations`                | Imaginary pod tolerations                                                | `[]`              |
+| `imaginary.nodeSelector`               | Imaginary pod nodeSelector                                                              | `{}`              |
+| `imaginary.tolerations`                | Imaginary pod tolerations                                                               | `[]`              |
 | `imaginary.resources`                  | imaginary resources                                                                     | `{}`              |
 | `imaginary.securityContext`            | Optional security context for the Imaginary container                                   | `nil`             |
 | `imaginary.podSecurityContext`         | Optional security context for the Imaginary pod (applies to all containers in the pod)  | `nil`             |
@@ -567,6 +567,50 @@ nextcloud:
 imaginary:
   enabled: true
 ```
+
+
+### Whiteboard
+
+The chart can optionally also deploy the whiteboard backend to use with the [Nextcloud Whiteboard](https://github.com/nextcloud/whiteboard) app.
+
+| Parameter                                   | Description                                                                                          | Default                         |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `whiteboard.enabled`                        | Start Whiteboard                                                                                     | `false`                         |
+| `whiteboard.replicaCount`                   | Number of whiteboard pod replicas to deploy                                                          | `1`                             |
+| `whiteboard.host`                           | Whiteboard host domain                                                                               | `whiteboard.kube.home`          |
+| `whiteboard.https`                          | Defines if https is used to connect to Whiteboard. Used to configure the whiteboard URL in Nextcloud | `false`                         |
+| `whiteboard.nextcloudUrl`                   | Nextcloud Server URL to connect Whiteboard to. If not provided, defaults to service name             | `""`                            |
+| `whiteboard.nextcloudHttps`                 | Defines if https is used to connect from Whiteboard to Nextcloud when using the default URL          | `false` (uses http)             |
+| `whiteboard.image.registry`                 | Whiteboard image registry                                                                            | `ghcr.io`                       |
+| `whiteboard.image.repository`               | Whiteboard image repository                                                                          | `nextcloud-releases/whiteboard` |
+| `whiteboard.image.tag`                      | Whiteboard image tag                                                                                 | `v1.0.5`                        |
+| `whiteboard.image.pullPolicy`               | Whiteboard image pull policy                                                                         | `IfNotPresent`                  |
+| `whiteboard.image.pullSecrets`              | Whiteboard image pull secrets                                                                        | `nil`                           |
+| `whiteboard.existingSecret.enabled`         | Whether to use an existing secret or not                                                             | `false`                         |
+| `whiteboard.existingSecret.secretName`      | Name of the existing secret                                                                          | `nil`                           |
+| `whiteboard.existingSecret.jwtSecretKeyKey` | Name of the key that contains the JWT secret key                                                     | `nil`                           |
+| `whiteboard.jwtSecretKey`                   | JWT secret key if no existing secret is used                                                         | random value                    |
+| `whiteboard.podAnnotations`                 | Additional annotations for whiteboard                                                                | `{}`                            |
+| `whiteboard.podLabels`                      | Additional labels for whiteboard                                                                     | `{}`                            |
+| `whiteboard.nodeSelector`                   | Whiteboard pod nodeSelector                                                                          | `{}`                            |
+| `whiteboard.tolerations`                    | Whiteboard pod tolerations                                                                           | `[]`                            |
+| `whiteboard.resources`                      | whiteboard resources                                                                                 | `{}`                            |
+| `whiteboard.securityContext`                | Optional security context for the Whiteboard container                                               | `nil`                           |
+| `whiteboard.podSecurityContext`             | Optional security context for the Whiteboard pod (applies to all containers in the pod)              | `nil`                           |
+| `whiteboard.service.type`                   | Whiteboard: Kubernetes Service type                                                                  | `ClusterIP`                     |
+| `whiteboard.service.loadBalancerIP`         | Whiteboard: LoadBalancerIp for service type LoadBalancer                                             | `nil`                           |
+| `whiteboard.service.nodePort`               | Whiteboard: NodePort for service type NodePort                                                       | `nil`                           |
+| `whiteboard.service.annotations`            | Additional annotations for service whiteboard                                                        | `{}`                            |
+| `whiteboard.service.labels`                 | Additional labels for service whiteboard                                                             | `{}`                            |
+| `whiteboard.ingress.className`              | Name of the ingress class to use                                                                     | `nil`                           |
+| `whiteboard.ingress.enabled`                | Enable use of ingress controllers                                                                    | `false`                         |
+| `whiteboard.ingress.servicePort`            | Ingress' backend servicePort                                                                         | `http`                          |
+| `whiteboard.ingress.annotations`            | An array of service annotations                                                                      | `nil`                           |
+| `whiteboard.ingress.labels`                 | An array of service labels                                                                           | `nil`                           |
+| `whiteboard.ingress.path`                   | The `Path` to use in Ingress' `paths`                                                                | `/`                             |
+| `whiteboard.ingress.pathType`               | The `PathType` to use in Ingress' `paths`                                                            | `Prefix`                        |
+| `whiteboard.ingress.tls`                    | Ingress TLS configuration                                                                            | `[]`                            |
+
 
 ## Cron jobs
 

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -85,6 +85,12 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
+            {{- if .Values.whiteboard.enabled }}
+            - name: whiteboard-hook
+              mountPath: /docker-entrypoint-hooks.d/before-starting/configure-whiteboard.sh
+              subPath: configure-whiteboard.sh
+              readOnly: true
+            {{- end }}
           {{- if not .Values.nginx.enabled }}
           ports:
             - name: http
@@ -366,6 +372,12 @@ spec:
         - name: nextcloud-nginx-config
           configMap:
             name: {{ template "nextcloud.fullname" . }}-nginxconfig
+        {{- end }}
+        {{- if .Values.whiteboard.enabled }}
+        - name: whiteboard-hook
+          configMap:
+            name: {{ template "nextcloud.whiteboard.fullname" . }}-hook
+            defaultMode: 0o755
         {{- end }}
         {{- if not (values .Values.nextcloud.hooks | compact | empty) }}
         - name: nextcloud-hooks

--- a/charts/nextcloud/templates/whiteboard/deployment.yaml
+++ b/charts/nextcloud/templates/whiteboard/deployment.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.whiteboard.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nextcloud.whiteboard.fullname" . }}
+  labels:
+    {{- include "nextcloud.labels"  ( dict "component" "whiteboard"  "rootContext" $ ) | nindent 4 }}
+spec:
+  replicas: {{ .Values.whiteboard.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: whiteboard
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.whiteboard.podAnnotations | nindent 8 }}
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: whiteboard
+        {{- with .Values.whiteboard.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.whiteboard.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: whiteboard
+          {{- with .Values.whiteboard.image }}
+          image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          env:
+            {{- if not .Values.whiteboard.nextcloudUrl }}
+            - name: NEXTCLOUD_URL
+              value: "http{{ if .Values.whiteboard.nextcloudHttps }}s{{ end }}://{{ template "nextcloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+            {{- else }}
+            - name: NEXTCLOUD_URL
+              value: {{ .Values.whiteboard.nextcloudUrl }}
+            {{- end }}
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.whiteboard.existingSecret.secretName | default (include "nextcloud.whiteboard.fullname" .) }}
+                  key: {{ .Values.whiteboard.existingSecret.jwtSecretKeyKey | default "whiteboard-jwt-secret-key" }}
+          ports:
+            - name: http
+              containerPort: 3002
+          volumeMounts:
+            - name: whiteboard-backup
+              mountPath: /app/backup
+          {{- with .Values.whiteboard.readinessProbe }}
+          {{- if .enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            failureThreshold: {{ .failureThreshold }}
+            successThreshold: {{ .successThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.whiteboard.livenessProbe }}
+          {{- if .enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            failureThreshold: {{ .failureThreshold }}
+            successThreshold: {{ .successThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.whiteboard.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.whiteboard.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: whiteboard-backup
+          emptyDir:
+            size: 500Mi
+      {{- with .Values.whiteboard.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- with .Values.whiteboard.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.whiteboard.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/whiteboard/hook-configmap.yaml
+++ b/charts/nextcloud/templates/whiteboard/hook-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.whiteboard.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.whiteboard.fullname" . }}-hook
+  labels:
+    {{- include "nextcloud.labels"  ( dict "component" "whiteboard"  "rootContext" $ ) | nindent 4 }}
+data:
+  configure-whiteboard.sh: |
+    #!/bin/sh
+    echo "Configuring whiteboard..."
+    ./occ config:app:set whiteboard collabBackendUrl --value="${WHITEBOARD_URL}"
+    ./occ config:app:set whiteboard jwt_secret_key --value="${WHITEBOARD_JWT_SECRET_KEY}"
+{{- end }}

--- a/charts/nextcloud/templates/whiteboard/ingress.yaml
+++ b/charts/nextcloud/templates/whiteboard/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.whiteboard.enabled .Values.whiteboard.ingress.enabled }}
+---
+apiVersion: {{ include "nextcloud.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ template "nextcloud.whiteboard.fullname" . }}
+  labels:
+    {{- include "nextcloud.labels"  ( dict "component" "whiteboard"  "rootContext" $ ) | nindent 4 }}
+    {{- with .Values.whiteboard.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.whiteboard.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.whiteboard.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.whiteboard.host }}
+      http:
+        paths:
+          - path: {{ .Values.whiteboard.ingress.path }}
+            {{- if (eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1") }}
+            pathType: {{ .Values.whiteboard.ingress.pathType }}
+            {{- end }}
+            backend:
+              {{- if (eq (include "nextcloud.ingress.apiVersion" $) "networking.k8s.io/v1") }}
+              service:
+                name: {{ template "nextcloud.whiteboard.fullname" . }}
+                port:
+                  number: {{ .Values.whiteboard.service.port }}
+              {{- else }}
+              serviceName: {{ template "nextcloud.whiteboard.fullname" . }}
+              servicePort: {{ .Values.whiteboard.service.port }}
+              {{- end }}
+  {{- with .Values.whiteboard.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/whiteboard/secrets.yaml
+++ b/charts/nextcloud/templates/whiteboard/secrets.yaml
@@ -1,0 +1,12 @@
+{{ if and .Values.whiteboard.enabled (not .Values.whiteboard.existingSecret.enabled) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nextcloud.whiteboard.fullname" . }}
+  labels:
+    {{- include "nextcloud.labels"  ( dict "component" "whiteboard"  "rootContext" $ ) | nindent 4 }}
+type: Opaque
+data:
+  whiteboard-jwt-secret-key: {{ .Values.whiteboard.jwtSecretKey | default (randAlphaNum 32)  | b64enc | quote }}
+{{- end }}

--- a/charts/nextcloud/templates/whiteboard/service.yaml
+++ b/charts/nextcloud/templates/whiteboard/service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.whiteboard.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nextcloud.whiteboard.fullname" . }}
+  labels:
+    {{- include "nextcloud.labels"  ( dict "component" "whiteboard"  "rootContext" $ ) | nindent 4 }}
+    {{- with .Values.whiteboard.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.whiteboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.whiteboard.service.type }}
+  {{- with .Values.whiteboard.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.whiteboard.service.port }}
+      targetPort: 3002
+      {{- with .Values.whiteboard.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: whiteboard
+{{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -756,6 +756,112 @@ imaginary:
     # -- Additional labels for service imaginary
     labels: {}
 
+whiteboard:
+  # -- Start Whiteboard Backend
+  enabled: false
+  # -- Number of whiteboard pod replicas to deploy
+  replicaCount: 1
+  # -- Hostname of the whiteboard backend service
+  host: whiteboard.kube.home
+  # -- Set to true if the whiteboard backend uses https (used to configure the whiteboard URL in Nextcloud)
+  https: false
+
+  # Optional: becomes NEXTCLOUD_URL env var in the whiteboard backend container.
+  # Without it, we will use the full name of the nextcloud service
+  nextcloudUrl: ""
+  # The whiteboard backend needs to know how you serve Nextcloud either http or https
+  nextcloudHttps: false
+
+  image:
+    # -- Whiteboard image registry
+    registry: ghcr.io
+    # -- Whiteboard image name
+    repository: nextcloud-releases/whiteboard
+    # -- Whiteboard image tag
+    tag: v1.0.5
+    # -- Whiteboard image pull policy
+    pullPolicy: IfNotPresent
+    # -- Whiteboard image pull secrets
+    pullSecrets: []
+
+  existingSecret:
+    # set to true to to get whiteboard JWT secret key from an existin secret
+    # will fall back to the value provided in jwtSecretKey if not enabled
+    enabled: false
+    # name of existing Kubernetes Secret with whiteboard JWT secret key
+    secretName: ""
+    # Key in existing secret with JWT secret key
+    jwtSecretKeyKey: "whiteboard-jwt-secret-key"
+  # -- Whiteboard JWT secret key - if not provided, a random key will be generated
+  jwtSecretKey: ""
+
+  # -- Additional annotations for whiteboard
+  podAnnotations: {}
+  # -- Additional labels for whiteboard
+  podLabels: {}
+  # -- Whiteboard pod nodeSelector
+  nodeSelector: {}
+  # -- Whiteboard pod tolerations
+  tolerations: []
+
+  # -- whiteboard resources
+  resources: {}
+
+  # -- Optional security context for the Whiteboard container
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: true
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+
+  # -- Optional security context for the Whiteboard pod (applies to all containers in the pod)
+  podSecurityContext: {}
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+  readinessProbe:
+    enabled: false
+    failureThreshold: 3
+    successThreshold: 1
+    periodSeconds: 10
+    timeoutSeconds: 1
+  livenessProbe:
+    enabled: false
+    failureThreshold: 3
+    successThreshold: 1
+    periodSeconds: 10
+    timeoutSeconds: 1
+
+  service:
+    # -- Whiteboard: Kubernetes Service type
+    type: ClusterIP
+    port: 3002
+    # -- Whiteboard: LoadBalancerIp for service type LoadBalancer
+    loadBalancerIP:
+    # -- Whiteboard: NodePort for service type NodePort
+    nodePort:
+    # -- Additional annotations for service whiteboard
+    annotations: {}
+    # -- Additional labels for service whiteboard
+    labels: {}
+
+  ingress:
+    enabled: false
+    # className: nginx
+    annotations: {}
+    #  kubernetes.io/tls-acme: "true"
+    #  cert-manager.io/cluster-issuer: letsencrypt-prod
+    # tls:
+    #   - secretName: whiteboard-tls
+    #     hosts:
+    #       - whiteboard.kube.home
+    labels: {}
+    path: /
+    pathType: Prefix
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR adds an option to deploy the backend server for the [Nextcloud Whiteboard](https://github.com/nextcloud/whiteboard) app. It also includes another ingress to expose the backend server to the user. A startup hook automatically configures the required URL and JWT_SECRET_KEY for the Nextcloud Whiteboard app to connect to the backend server.

## Benefits

<!-- What benefits will be realized by the code change? -->
This change provides an easy way to deploy the Whiteboard backend.

## Possible drawbacks

<!-- Describe any known limitations with your change -->
Unless `whiteboard.enabled` is set to `true` nothing will change. 

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- closes #701 

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
I tested this change on my personal Nextcloud instance where I run with Ingresses and TLS enabled. I'm not sure if there need to be additional adjustments for other setups. 

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
