### PR TITLE
feature(nextcloud): Allow specifying service session affinity in helm chart

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 7.0.2
+version: 7.0.3
 # renovate: image=docker.io/library/nextcloud
 appVersion: 31.0.8
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -209,6 +209,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `service.ipFamilies`                                        | Set ipFamilies as in k8s service objects                                                            | `nil`                      |
 | `service.ipFamyPolicy`                                      | define IP protocol bindings as in k8s service objects                                               | `nil`                      |
 | `service.sessionAffinity`                                   | Kubernetes service Session Affinity                                                                 | `nil`                     |
+| `service.sessionAffinityConfig`                                   | Kubernetes service Session Affinity configuration                                                            | `{}`                     |
 | `phpClientHttpsFix.enabled`                                 | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `false`                    |
 | `phpClientHttpsFix.protocol`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `https`                    |
 | `resources`                                                 | CPU/Memory resource requests/limits                                                                 | `{}`                       |

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -208,6 +208,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `service.nodePort`                                          | NodePort for service type NodePort                                                                  | `nil`                      |
 | `service.ipFamilies`                                        | Set ipFamilies as in k8s service objects                                                            | `nil`                      |
 | `service.ipFamyPolicy`                                      | define IP protocol bindings as in k8s service objects                                               | `nil`                      |
+| `service.sessionAffinity`                                   | Kubernetes service Session Affinity                                                                 | `nil`                     |
 | `phpClientHttpsFix.enabled`                                 | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `false`                    |
 | `phpClientHttpsFix.protocol`                                | Sets OVERWRITEPROTOCOL for https ingress redirect                                                   | `https`                    |
 | `resources`                                                 | CPU/Memory resource requests/limits                                                                 | `{}`                       |

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{- with .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
+  {{- with .Values.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nextcloud.containerPort }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -26,6 +26,10 @@ spec:
   {{- with .Values.service.sessionAffinity }}
   sessionAffinity: {{ . }}
   {{- end }}
+  {{- with .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nextcloud.containerPort }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -596,6 +596,9 @@ service:
   nodePort:
   # -- use additional annotation on service for nextcloud
   annotations: {}
+  # -- Set this to "ClientIP" to make sure that connections from the same client
+  # are passed to the same Nextcloud pod each time.
+  sessionAffinity: ""
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -599,6 +599,7 @@ service:
   # -- Set this to "ClientIP" to make sure that connections from the same client
   # are passed to the same Nextcloud pod each time.
   sessionAffinity: ""
+  sessionAffinityConfig: {}
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
… chart

## Description of the change

Services in kubernetes have the notion of [session affinity](https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity) which allow a given client to be sent to the same backend.

## Benefits

When multiple instances of Nextcloud are deployed (for high availability), certain applications may break, for instance because a CSRF token is generated in one pod, and evaluated in another pod.

This feature mitigates this sort of application bugs.

## Possible drawbacks

When enabled, the load between the pods may become uneven. However this is a choice of the administrator.


## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
