### PR TITLE
Bump collabora to helm chart to 1.1.47

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 7.0.2
+version: 7.0.3
 # renovate: image=docker.io/library/nextcloud
 appVersion: 31.0.8
 description: A file sharing server that puts the control and security of your own data back into your hands.
@@ -40,7 +40,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: collabora-online
-    version: 1.1.20
+    version: 1.1.47
     repository: https://collaboraonline.github.io/online
     condition: collabora.enabled
     alias: collabora


### PR DESCRIPTION
## Description of the change

Bumps the collabora helm chart to 1.1.47 as that's the latest release as of right now:
https://github.com/CollaboraOnline/online/blob/05a4be4b5a2a19b602226337084756d2d9961049/kubernetes/helm/collabora-online/Chart.yaml#L7

## Benefits

We were quite a few patch versions behind.

## Possible drawbacks

None that I can think of, but happy to chat about them!

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
