### PR TITLE
Fixed cronjob template not matching values

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.0.0
+version: 8.0.1
 # renovate: image=docker.io/library/nextcloud
 appVersion: 31.0.8
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               image: {{ include "nextcloud.image" $ }}
               imagePullPolicy: {{ $.Values.image.pullPolicy }}
               command:
-                {{- toYaml .commandCronJob | nindent 16 }}
+                {{- toYaml .command | nindent 16 }}
               env:
                 {{- include "nextcloud.env" $ | nindent 16 }}
               resources:


### PR DESCRIPTION
Changelog: fixed

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This fixes the template not matching the values.yaml, leading to unexpected issues with lack of command overrides: https://github.com/nextcloud/helm/issues/771

## Benefits

Fixes the templates to make them in-line with our values.yaml

## Possible drawbacks

None, fixes to spec

## Applicable issues

issue: https://github.com/nextcloud/helm/issues/771

## Additional information

related to recent feature from: https://github.com/nextcloud/helm/pull/740

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
