### PR TITLE
feat: adds topologySpreadConstraints for nextcloud pod, cronjob pod a…

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.2.0
+version: 8.3.0
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -245,6 +245,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `podLabels`                                                 | Labels to be added at 'pod' level                                                                   | not set                                                      |
 | `podAnnotations`                                            | Annotations to be added at 'pod' level                                                              | not set                                                      |
 | `dnsConfig`                                                 | Custom dnsConfig for nextcloud containers                                                           | `{}`                                                         |
+| `topologySpreadConstraints`                                 | TopologySpreadConstraints for nextcloud pod and cronjob pod                                         | `{}`                                                         |
 
 ### Ingress
 #### Ingress Sticky-Sessions
@@ -561,27 +562,28 @@ This section provides options to enable and configure the Collabora Online serve
 
 We include an optional external preview provider from [h2non/imaginary](https://github.com/h2non/imaginary).
 
-| Parameter                          | Description                                                                            | Default           |
-| ---------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| `imaginary.enabled`                | Start Imaginary                                                                        | `false`           |
-| `imaginary.replicaCount`           | Number of imaginary pod replicas to deploy                                             | `1`               |
-| `imaginary.image.registry`         | Imaginary image name                                                                   | `docker.io`       |
-| `imaginary.image.repository`       | Imaginary image name                                                                   | `h2non/imaginary` |
-| `imaginary.image.tag`              | Imaginary image tag                                                                    | `1.2.4`           |
-| `imaginary.image.pullPolicy`       | Imaginary image pull policy                                                            | `IfNotPresent`    |
-| `imaginary.image.pullSecrets`      | Imaginary image pull secrets                                                           | `nil`             |
-| `imaginary.podAnnotations`         | Additional annotations for imaginary                                                   | `{}`              |
-| `imaginary.podLabels`              | Additional labels for imaginary                                                        | `{}`              |
-| `imaginary.nodeSelector`           | Imaginary pod nodeSelector                                                             | `{}`              |
-| `imaginary.tolerations`            | Imaginary pod tolerations                                                              | `[]`              |
-| `imaginary.resources`              | imaginary resources                                                                    | `{}`              |
-| `imaginary.securityContext`        | Optional security context for the Imaginary container                                  | `nil`             |
-| `imaginary.podSecurityContext`     | Optional security context for the Imaginary pod (applies to all containers in the pod) | `nil`             |
-| `imaginary.service.type`           | Imaginary: Kubernetes Service type                                                     | `ClusterIP`       |
-| `imaginary.service.loadBalancerIP` | Imaginary: LoadBalancerIp for service type LoadBalancer                                | `nil`             |
-| `imaginary.service.nodePort`       | Imaginary: NodePort for service type NodePort                                          | `nil`             |
-| `imaginary.service.annotations`    | Additional annotations for service imaginary                                           | `{}`              |
-| `imaginary.service.labels`         | Additional labels for service imaginary                                                | `{}`              |
+| Parameter                             | Description                                                                            | Default           |
+| ------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| `imaginary.enabled`                   | Start Imaginary                                                                        | `false`           |
+| `imaginary.replicaCount`              | Number of imaginary pod replicas to deploy                                             | `1`               |
+| `imaginary.image.registry`            | Imaginary image name                                                                   | `docker.io`       |
+| `imaginary.image.repository`          | Imaginary image name                                                                   | `h2non/imaginary` |
+| `imaginary.image.tag`                 | Imaginary image tag                                                                    | `1.2.4`           |
+| `imaginary.image.pullPolicy`          | Imaginary image pull policy                                                            | `IfNotPresent`    |
+| `imaginary.image.pullSecrets`         | Imaginary image pull secrets                                                           | `nil`             |
+| `imaginary.podAnnotations`            | Additional annotations for imaginary                                                   | `{}`              |
+| `imaginary.podLabels`                 | Additional labels for imaginary                                                        | `{}`              |
+| `imaginary.nodeSelector`              | Imaginary pod nodeSelector                                                             | `{}`              |
+| `imaginary.tolerations`               | Imaginary pod tolerations                                                              | `[]`              |
+| `imaginary.topologySpreadConstraints` | Imaginary pod topologySpreadConstraints                                                | `[]`              |
+| `imaginary.resources`                 | imaginary resources                                                                    | `{}`              |
+| `imaginary.securityContext`           | Optional security context for the Imaginary container                                  | `nil`             |
+| `imaginary.podSecurityContext`        | Optional security context for the Imaginary pod (applies to all containers in the pod) | `nil`             |
+| `imaginary.service.type`              | Imaginary: Kubernetes Service type                                                     | `ClusterIP`       |
+| `imaginary.service.loadBalancerIP`    | Imaginary: LoadBalancerIp for service type LoadBalancer                                | `nil`             |
+| `imaginary.service.nodePort`          | Imaginary: NodePort for service type NodePort                                          | `nil`             |
+| `imaginary.service.annotations`       | Additional annotations for service imaginary                                           | `{}`              |
+| `imaginary.service.labels`            | Additional labels for service imaginary                                                | `{}`              |
 
 
 > [!Note]

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -64,6 +64,10 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.topologySpreadConstraints }}
+          topologySpreadConstraints:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}{{/* end with cronjob */}}
           volumes:
             - name: nextcloud-main

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -341,6 +341,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: nextcloud-main
           {{- if .Values.persistence.enabled }}

--- a/charts/nextcloud/templates/imaginary/deployment.yaml
+++ b/charts/nextcloud/templates/imaginary/deployment.yaml
@@ -85,4 +85,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imaginary.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -781,6 +781,8 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}
 
 dnsConfig: {}
@@ -816,6 +818,8 @@ imaginary:
   nodeSelector: {}
   # -- Imaginary pod tolerations
   tolerations: []
+  # -- Imaginary pod topologySpreadConstraints
+  topologySpreadConstraints: []
 
   # -- imaginary resources
   resources: {}


### PR DESCRIPTION
## Description of the change

Adds topologySpreadConstraints for nextcloud and imaginary pods.

## Benefits

Allow user to set topologySpreadConstraints.

## Possible drawbacks

N/A

## Applicable issues

- fixes #778 

## Additional information

N/A

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
