### PR TITLE
chore(nextcloud): lower outdated apps prometheus alertrule to info

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.2.0
+version: 8.2.1
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/metrics/prometheus-rules.yaml
+++ b/charts/nextcloud/templates/metrics/prometheus-rules.yaml
@@ -42,7 +42,7 @@ spec:
         - alert: "nextcloud: outdated apps"
           expr: 'sum(nextcloud_apps_updates_available_total{ {{ $filter }} }) without(endpoint,container,pod,instance) > 0'
           labels:
-            severity: "warning"
+            severity: "info"
             {{- with .labels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

I lowered the severity from warning to info for the outdated apps prometheus alert rule

## Benefits

<!-- What benefits will be realized by the code change? -->

imo the outdated apps are not relevant enough that it should be a warning, im not sure how most people have the severities set up, but i send alerts for warning and critical, and usually i just leave the apps outdated until i do a nextcloud update, which will update the apps anyway.

## Possible drawbacks

<!-- Describe any known limitations with your change -->


## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

This is the only thing bugging me about the default alert rules, so i thought I'd just propose the change and see what you think :) Thanks in advance for looking over it.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
