### PR TITLE
fix: correct error when no podLabel is defined

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.4.0
+version: 8.4.1
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
       template:
         metadata:
           labels:
-            {{- with (mergeOverwrite (dict) $.Values.podLabels .podLabels) }}
+            {{- with (mergeOverwrite (dict) (default dict $.Values.podLabels) (default dict .podLabels)) }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:


### PR DESCRIPTION
## Description of the change

Use default to ensure that both .Values.podLabels and .podLabels are always maps, even if undefined.

## Benefits

Fixes error:
```
template: nextcloud/templates/cronjob.yaml:34:45: executing "nextcloud/templates/cronjob.yaml" at <$.Values.podLabels>: wrong type for value; expected map[string]interface {}; got interface {}]
```

## Possible drawbacks

N/A

## Applicable issues

- fixes #787 

## Additional information

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
