### PR TITLE
fix(values): set registry

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.5.3
+version: 8.5.4
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -43,9 +43,9 @@ Create image name that is used in the deployment
 */}}
 {{- define "nextcloud.image" -}}
 {{- if .Values.image.tag -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- printf "%s/%s:%s" (coalesce .Values.global.image.registry .Values.image.registry) .Values.image.repository .Values.image.tag -}}
 {{- else -}}
-{{- printf "%s/%s:%s-%s" .Values.image.registry .Values.image.repository .Chart.AppVersion .Values.image.flavor -}}
+{{- printf "%s/%s:%s-%s" (coalesce .Values.global.image.registry .Values.image.registry) .Values.image.repository .Chart.AppVersion .Values.image.flavor -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -288,7 +288,7 @@ spec:
         {{- end }}
         {{- if .Values.mariadb.enabled }}
         - name: mariadb-isalive
-          image: {{ .Values.mariadb.image.registry | default "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
+          image: {{ coalesce .Values.global.image.registry .Values.mariadb.image.registry "docker.io" }}/{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}
           {{- with .Values.nextcloud.mariaDbInitContainer }}
           resources:
             {{- toYaml .resources | nindent 12 }}
@@ -312,7 +312,7 @@ spec:
             - {{ printf "until mysql --host=%s-mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute=\"SELECT 1;\"; do echo waiting for mysql; sleep 2; done;" .Release.Name }}
         {{- else if .Values.postgresql.enabled }}
         - name: postgresql-isready
-          image: {{ .Values.postgresql.image.registry | default "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+          image: {{ coalesce .Values.global.image.registry .Values.postgresql.image.registry "docker.io"  }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
           {{- with .Values.nextcloud.postgreSqlInitContainer }}
           resources:
             {{- toYaml .resources | nindent 12 }}

--- a/charts/nextcloud/templates/metrics/deployment.yaml
+++ b/charts/nextcloud/templates/metrics/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
         - name: metrics-exporter
-          image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          image: "{{ coalesce .Values.global.image.registry .Values.metrics.image.registry  }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           env:
             {{- if or .Values.metrics.token .Values.nextcloud.existingSecret.tokenKey }}

--- a/charts/nextcloud/values-metrics.yaml
+++ b/charts/nextcloud/values-metrics.yaml
@@ -1,0 +1,9 @@
+metrics:
+  enabled: true
+  rules:
+    enabled: true
+    labels:
+      prometheus: default
+    defaults:
+      labels:
+        test: demo

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -1,3 +1,12 @@
+global:
+  image:
+   # -- if set it will overwrite all registry entries
+    registry:
+
+  security:
+    # required for bitnamilegacy repos
+    allowInsecureImages: true
+
 ## ref: https://hub.docker.com/r/library/nextcloud/tags/
 ##
 image:
@@ -413,11 +422,6 @@ externalDatabase:
     passwordKey: db-password
     # hostKey: db-hostname-or-ip
     # databaseKey: db-name
-
-global:
-  security:
-    # required for bitnamilegacy repos
-    allowInsecureImages: true
 
 ##
 ## MariaDB chart configuration


### PR DESCRIPTION
The following patch adds the `registry` attribute. It also sets the `registry` attribute for all helm chart dependencies.

This is necessary to protect CRIO users from a breaking change in v1.34. Further information can be found in the following [pr](https://github.com/cri-o/cri-o/pull/9401) of cri-o.

  Volker