### PR TITLE
fix(collabora): Bump collabora to helm chart to 1.1.53 #769

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 21.1.3
 - name: collabora-online
   repository: https://collaboraonline.github.io/online
-  version: 1.1.20
-digest: sha256:47979e007ed8bb4a53ec00c5e457da110573a6e067f24da505144f475b26981c
-generated: "2025-05-18T15:22:37.968306345+02:00"
+  version: 1.1.53
+digest: sha256:e9dd12da1b4620c951171a92aca12ef98e669627f0139937290087718ecd6e84
+generated: "2025-11-21T19:42:03.09934126+01:00"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.5.6
+version: 8.5.7
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
@@ -40,7 +40,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: collabora-online
-    version: 1.1.47
+    version: 1.1.53
     repository: https://collaboraonline.github.io/online
     condition: collabora.enabled
     alias: collabora


### PR DESCRIPTION
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #769

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
