### PR TITLE
fix(cronjob): labels wrong indent

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.5.9
+version: 8.5.10
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/cronjob.yaml
+++ b/charts/nextcloud/templates/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
       template:
         metadata:
           labels:
-            {{- include "nextcloud.selectorLabels"  ( dict "component" "cronjob" "rootContext" $ ) | nindent 10 }}
+            {{- include "nextcloud.selectorLabels"  ( dict "component" "cronjob" "rootContext" $ ) | nindent 12 }}
             {{- with (mergeOverwrite (dict) $.Values.podLabels .podLabels) }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Description of the change

wrong indent from latest change on `cronJob`  `Labels`
## Benefits

work as expected

## Possible drawbacks

Out Of sync on gitops tools

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
