### PR TITLE
Add dataVolumeMount option

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 8.6.0
+version: 8.7.0
 # renovate: image=docker.io/library/nextcloud
 appVersion: 32.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -405,6 +405,7 @@ Nextcloud will *not* delete the PVCs when uninstalling the helm chart.
 | `persistence.existingClaim`               | An Existing PVC name for nextcloud volume            | `nil`           |
 | `persistence.accessMode`                  | PVC Access Mode for nextcloud volume                 | `ReadWriteOnce` |
 | `persistence.size`                        | PVC Storage Request for nextcloud volume             | `8Gi`           |
+| `persistence.dataVolumeMount`             | Toggle automatic mount of data volume                | `true`          |
 | `persistence.nextcloudData.enabled`       | Create a second PVC for the data folder in nextcloud | `false`         |
 | `persistence.nextcloudData.annotations`   | see `persistence.annotations`                        | `{}`            |
 | `persistence.nextcloudData.labels`       | see `persistence.labels`                             | `{}`            |

--- a/charts/nextcloud/templates/_helpers.tpl
+++ b/charts/nextcloud/templates/_helpers.tpl
@@ -374,7 +374,7 @@ Create volume mounts for the nextcloud container as well as the cron sidecar con
 - name: nextcloud-data
   mountPath: {{ .Values.nextcloud.datadir }}
   subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.nextcloudData.subPath) (empty .Values.persistence.nextcloudData.subPath) }}
-{{- else }}
+{{- else if .Values.persistence.dataVolumeMount }}
 - name: nextcloud-main
   mountPath: {{ .Values.nextcloud.datadir }}
   subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.subPath) (empty .Values.persistence.subPath) }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -217,7 +217,7 @@ spec:
             - name: nextcloud-data
               mountPath: {{ .Values.nextcloud.datadir }}
               subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.nextcloudData.subPath) (empty .Values.persistence.nextcloudData.subPath) }}
-            {{- else }}
+            {{- else if .Values.persistence.dataVolumeMount }}
             - name: nextcloud-main
               mountPath: {{ .Values.nextcloud.datadir }}
               subPath: {{ ternary "data" (printf "%s/data" .Values.persistence.subPath) (empty .Values.persistence.subPath) }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -739,6 +739,12 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
+  # Set this to false if you want to provide your own data directory via
+  # extraVolumes and extraVolumeMounts. Make sure to mount the folder at at the
+  # nextcloud.datadir path.
+  # Ignored if nextcloudData.enabled: true
+  dataVolumeMount: true
+
   ## Use an additional pvc for the data directory rather than a subpath of the default PVC
   ## Useful to store data on a different storageClass (e.g. on slower disks)
   nextcloudData:


### PR DESCRIPTION
## Description of the change

By default, when persistence is enabled, the volume "nextcloud-main" is used to store Nextcloud data. The chart offers an option to create an extra PVC using `persistence.nextcloudData`.

However, it's not possible to mount data from an external source. Even though `extraVolumes` and `extraVolumeMounts` are available, the data folder is either sourced from "nextcloud-main" or "nextcloud-data".

By providing an option to skip mounting the "data" subfolder when using the main persistence option, but not the `nextcloudData` option, it is possible to provide a custom volume mount based on a different volume specified in `extraVolumes`.

This allows, for example, to supply an NFS mount point:

```yaml
nextcloud:
  extraVolumes:
    - name: data
      nfs:
        path: /mnt/nextcloud
        server: my-nfs-server.example.com

  extraVolumeMounts:
    - name: data
      mountPath: /var/www/html/data

persistence:
  # Create a PVC to store Nextcloud application data
  enabled: true
  # But don't mount the user data folder, as it is provided above
  dataVolumeMount: false
```

## Benefits

Users with specific storage setup can customise how their data gets mounted. For example, I have an existing Nextcloud installation that I want to migrate to Kubernetes, but the data is already in an NFS server and I just want to mount that.

## Possible drawbacks

It's  possible I missed a configuration combination that doesn't make sense here, there are many ways to combine options in this chart.

## Applicable issues

N/A

## Additional information

I've first tried to use the NFS CSI driver, but it caused quite a few issues. This would have worked without needing to change the helm chart. However, it did not work out due to all problems this caused me.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] (optional) Parameters are documented in the README.md
