### PR TITLE
fix: update collabora-online to 1.1.60

### DIFF
--- a/charts/nextcloud/Chart.lock
+++ b/charts/nextcloud/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 21.1.3
 - name: collabora-online
   repository: https://collaboraonline.github.io/online
-  version: 1.1.58
-digest: sha256:af5b35a4f525927414be3988bfb3d7da0eda20450888f097f209e8de83e345e0
-generated: "2026-03-01T20:12:59.741424272Z"
+  version: 1.1.60
+digest: sha256:d23b1ed8608eebf338fce515241497aba8038c3fb3a336fd6dc405568708a120
+generated: "2026-03-29T15:58:20.663360455Z"

--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.0.3
+version: 9.0.4
 # renovate: image=docker.io/library/nextcloud
 appVersion: 33.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
@@ -40,7 +40,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: collabora-online
-    version: 1.1.58
+    version: 1.1.60
     repository: https://collaboraonline.github.io/online
     condition: collabora.enabled
     alias: collabora


### PR DESCRIPTION
## Description of the change

Update `collabora-online` to 1.1.60.

## Benefits

Latest version.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
