### PR TITLE
Add post deployment note in readme

### DIFF
--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -809,6 +809,15 @@ kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ maintenance:mo
 kubectl exec $NEXTCLOUD_POD -- su -s /bin/sh www-data -c "php occ recognize:download-models"
 ```
 
+### Changing Parameters After Deployment
+Some parameters in `values.yaml`, such as `nextcloud.trustedDomains`, are only templated into the container environment during the initial installation.  
+Changes after deployment must be made by redeploying the Helm chart or manually inside the pod using the `occ` command. Example of a manual change:
+
+```bash
+# Add a new trusted domain after deployment
+kubectl exec -it <your-nextcloud-pod> -- /bin/sh -c "php occ config:system:set trusted_domains 2 --value=nextcloud.mydomain2.com"
+```
+
 ## Injecting Additional Manifests (`extraManifests`)
 
 You can inject additional Kubernetes manifests (such as Traefik IngressRoutes, Middlewares, or any custom resources) directly via `values.yaml` using the `extraManifests` value.
@@ -854,15 +863,6 @@ extraManifests:
       name: my-ingressroute
     spec:
       ...
-```
-
-### Changing Parameters After Deployment
-Some parameters in `values.yaml`, such as `nextcloud.trustedDomains`, are only templated into the container environment during the initial installation.  
-Changes after deployment must be made by redeploying the Helm chart or manually inside the pod using the `occ` command. Example of a manual change:
-
-```bash
-# Add a new trusted domain after deployment
-kubectl exec -it <your-nextcloud-pod> -- /bin/sh -c "php occ config:system:set trusted_domains 2 --value=nextcloud.mydomain2.com"
 ```
 
 # Backups

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -140,7 +140,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.existingSecret.tokenKey`                         | Name of the key that contains the nextcloud metrics token                                           | `''`                                                         |
 | `nextcloud.update`                                          | Trigger update if custom command is used                                                            | `0`                                                          |
 | `nextcloud.containerPort`                                   | Customize container port when not running as root                                                   | `80`                                                         |
-| `nextcloud.trustedDomains`                                  | Optional space-separated list of trusted domains                                                    | `[]`                                                         |
+| `nextcloud.trustedDomains`                                  | Optional space-separated list of trusted domains (see [Running occ commands](#running-occ-commands) for post-deployment changes)                                                    | `[]`                                                         |
 | `nextcloud.datadir`                                         | nextcloud data dir location                                                                         | `/var/www/html/data`                                         |
 | `nextcloud.mail.enabled`                                    | Whether to enable/disable email settings                                                            | `false`                                                      |
 | `nextcloud.mail.fromAddress`                                | nextcloud mail send from field                                                                      | `nil`                                                        |
@@ -854,6 +854,15 @@ extraManifests:
       name: my-ingressroute
     spec:
       ...
+```
+
+### Changing Parameters After Deployment
+Some parameters in `values.yaml`, such as `nextcloud.trustedDomains`, are only templated into the container environment during the initial installation.  
+Changes after deployment must be made by redeploying the Helm chart or manually inside the pod using the `occ` command. Example of a manual change:
+
+```bash
+# Add a new trusted domain after deployment
+kubectl exec -it <your-nextcloud-pod> -- /bin/sh -c "php occ config:system:set trusted_domains 2 --value=nextcloud.mydomain2.com"
 ```
 
 # Backups


### PR DESCRIPTION
Updated charts/nextcloud > README.md as follows:

1. Added reference to section Running occ commands in table configuration > description for parameter nextcloud.trustedDomains.
2. Added subsection ###Changing Parameters After Deployment including explanation and example for nextcloud.trustedDomains.
4. Added subsection ###Changing Parameters After Deployment to section Running occ commands.

Closes issue #640 