### PR TITLE
Making use of .nginx.containerPort when fpm is enabled

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.0.5
+version: 9.0.6
 # renovate: image=docker.io/library/nextcloud
 appVersion: 33.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -150,13 +150,13 @@ spec:
           ports:
             - name: http
               protocol: TCP
-              containerPort: {{ .Values.nextcloud.containerPort }}
+              containerPort: {{ .Values.nginx.containerPort }}
           {{- with .Values.livenessProbe }}
           {{- if .enabled }}
           livenessProbe:
             httpGet:
               path: /status.php
-              port:  {{ $.Values.nextcloud.containerPort }}
+              port:  {{ $.Values.nginx.containerPort }}
               httpHeaders:
                 - name: Host
                   value: {{ $.Values.nextcloud.host | quote }}
@@ -172,7 +172,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status.php
-              port:  {{ $.Values.nextcloud.containerPort }}
+              port:  {{ $.Values.nginx.containerPort }}
               httpHeaders:
                 - name: Host
                   value: {{ $.Values.nextcloud.host | quote }}
@@ -188,7 +188,7 @@ spec:
           startupProbe:
             httpGet:
               path: /status.php
-              port:  {{ $.Values.nextcloud.containerPort }}
+              port:  {{ $.Values.nginx.containerPort }}
               httpHeaders:
                 - name: Host
                   value: {{ $.Values.nextcloud.host | quote }}

--- a/charts/nextcloud/templates/service.yaml
+++ b/charts/nextcloud/templates/service.yaml
@@ -34,7 +34,11 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
+      {{- if .Values.nginx.enabled }}
+      targetPort: {{ .Values.nginx.containerPort }}
+      {{- else }}
       targetPort: {{ .Values.nextcloud.containerPort }}
+      {{- end }}
       protocol: TCP
       {{- with .Values.service.nodePort }}
       nodePort: {{ . }}


### PR DESCRIPTION
This allows different nginx and fpm ports to be used, by utilizing the `.nginx.containerPort`, when fpm is enabled.