### PR TITLE
feat(httproute): add optional timeouts field

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.0.6
+version: 9.1.0
 # renovate: image=docker.io/library/nextcloud
 appVersion: 33.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/route.yaml
+++ b/charts/nextcloud/templates/route.yaml
@@ -38,5 +38,9 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -59,6 +59,8 @@ httpRoute:
   #         value: this-is-the-only-value
   #       remove:
   #       - User-Agent
+  #   timeouts:
+  #     request: 300s
   # - matches:
   #   - path:
   #       type: PathPrefix


### PR DESCRIPTION
## Description of the change

When using Gateway API's HTTPRoute, adds the option to configure the timeouts block ([Gateway API docs](https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional))

I found that the setup check on Nextcloud's `/settings/admin/overview` page times out because the request takes ~35 seconds. I run Envoy, which handles a 15 second timeout by default.

## Benefits

Allows for more customisation using standard features in the Gateway API spec. (nothing implementation-specific)

## Possible drawbacks

Internal structure of the `timeouts` block not declared and must be formed correctly in the values by the user. I figured this would be okay, since the `matches` and `filters` blocks behave the same way and are more complex. Please let me know if this should be changed, however.

Parameters are also not documented in the README, but so is the rest of the HTTPRoute setup...

## Applicable issues

- N/A (didn't make one)

## Additional information

- Tested locally with the following values:
```yaml
httpRoute:
  enabled: true
  hostnames:
    - my.example.hostname
  parentRefs:
    - name: main
      namespace: envoy-gateway-system
      sectionName: https-gateway
  rules:
    - timeouts:
        request: "300s"
```
And `helm template nextcloud charts/nextcloud --values examplevalues.yaml --show-only templates/route.yaml` to generate the route. Applied this to my cluster and the request doesn't time out now.

Bumped the chart a minor version because semver says I should bump "MINOR version when you add functionality in a backward compatible manner". Please let me know if that's OK in this case :)

## Checklist 

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
