### PR TITLE
fix(nextcloud): enable nginx config fastcgi_request_buffering

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.0.6
+version: 9.1.0
 # renovate: image=docker.io/library/nextcloud
 appVersion: 33.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/files/nginx.config.tpl
+++ b/charts/nextcloud/files/nginx.config.tpl
@@ -149,7 +149,7 @@ server {
         fastcgi_pass php-handler;
 
         fastcgi_intercept_errors on;
-        fastcgi_request_buffering off;
+        fastcgi_request_buffering on;
 
         fastcgi_max_temp_file_size 0;
     }


### PR DESCRIPTION
## Description of the change

Fixes https://github.com/nextcloud/helm/issues/854

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [X] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
