### PR TITLE
feat(nginx): lower client_max_body_size

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.1.1
+version: 9.1.2
 # renovate: image=docker.io/library/nextcloud
 appVersion: 33.0.4
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -416,7 +416,7 @@ nginx:
     # Added in server block of default config.
     serverBlockCustom: |
       # set max upload size
-      client_max_body_size 10G;
+      client_max_body_size 512M;
       client_body_timeout 300s;
       fastcgi_buffers 64 4K;
       fastcgi_read_timeout 3600s;


### PR DESCRIPTION
## Description of the change

This change lowers the Nginx configuration [client_max_body_size](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) to match the default [PHP_UPLOAD_LIMIT](https://github.com/nextcloud/docker/#php-configuration) of 512 MiB in the php-fpm docker image and also match the default nginx configuration in the [Nextcloud admin manual](https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html) after enabling `fastcgi_request_buffering` https://github.com/nextcloud/helm/pull/855

## Benefits

Lowering the configuration will reduces memory, disk pressure and also lowers risk of resource exhaustion.

`client_max_body_size` is set to 10 GiB which is an exceptionally large default value.

## Possible drawbacks

Some clients may not support chunked uploads and send the whole file in a single request. Nginx will reject the request if it is larger then `client_max_boy_size`.

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md