### PR TITLE
feat(nextcloud): add CalDAV/CardDAV redirects to HTTPRoute

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.2.1
+version: 9.2.2
 # renovate: image=docker.io/library/nextcloud
 appVersion: 34.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -707,6 +707,9 @@ ingress:
         deny all;
       }
 ```
+
+When exposing Nextcloud through the Gateway API (`httpRoute.enabled: true`), the CalDAV and CardDAV redirects are added automatically as `RequestRedirect` rules (`httpRoute.wellKnown.enabled`, on by default), so no implementation-specific configuration is required. Set `httpRoute.wellKnown.enabled: false` to opt out.
+
 ## Preserving Source IP
 
 - Make sure your loadbalancer preserves source IP, for bare metal, `metalb` does and `klipper-lb` doesn't.

--- a/charts/nextcloud/templates/route.yaml
+++ b/charts/nextcloud/templates/route.yaml
@@ -25,13 +25,37 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
+    {{- if .Values.httpRoute.wellKnown.enabled }}
+    {{- range $path := list "/.well-known/carddav" "/.well-known/caldav" }}
+    - matches:
+        - path:
+            type: Exact
+            value: {{ $path }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /remote.php/dav
+            statusCode: 301
+    {{- end }}
+    {{- end }}
     {{- range .Values.httpRoute.rules }}
-    - backendRefs:
+    {{- $isRedirect := false }}
+    {{- range .filters }}
+    {{- if eq (.type | default "") "RequestRedirect" }}
+    {{- $isRedirect = true }}
+    {{- end }}
+    {{- end }}
+    -
+      {{- if not $isRedirect }}
+      backendRefs:
         - group: ""
           kind: Service
           name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
+      {{- end }}
       {{- with .matches }}
       matches:
         {{- toYaml . | nindent 8 }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -45,6 +45,12 @@ httpRoute:
   hostnames: []
   # -- Reference to parent gateways
   parentRefs: []
+  # -- Add the standard Nextcloud service discovery redirects
+  # (`/.well-known/carddav` and `/.well-known/caldav` -> `/remote.php/dav`) as
+  # Gateway API `RequestRedirect` rules. Unlike the ingress-nginx server snippet
+  # this needs no implementation-specific config. Set to false to opt out.
+  wellKnown:
+    enabled: true
   # -- List of rules and filters applied.
   rules:
     - matches:


### PR DESCRIPTION
## Description of the change

The chart's `HTTPRoute` template (`route.yaml`) always added `backendRefs` to every rule, which made it impossible to define a rule using a `RequestRedirect` filter (Gateway API rejects `RequestRedirect` combined with `backendRefs`). This PR:

- Only renders `backendRefs` for rules that do not use a `RequestRedirect` filter, so redirect rules can now be defined.
- Adds the standard Nextcloud service discovery redirects (`/.well-known/carddav` and `/.well-known/caldav` -> `/remote.php/dav`) as `RequestRedirect` rules, gated behind `httpRoute.wellKnown.enabled` (on by default). With Gateway API these need no implementation-specific config.

## Benefits

CalDAV/CardDAV service discovery works out of the box for Gateway API users, matching the ingress-nginx server-snippet behaviour already documented in the README.

## Possible drawbacks

`httpRoute.wellKnown.enabled` defaults to `true`, so users who already enable `httpRoute` get the two redirect rules added on upgrade. Set `httpRoute.wellKnown.enabled: false` to opt out.

## Applicable issues

- fixes #860

## Additional information

Validated locally with `helm lint` and `helm template` for: default (redirects + catch-all), `wellKnown.enabled=false`, and a user-supplied `RequestRedirect` rule (confirmed no `backendRefs` is rendered).

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] DCO has been signed off on the commit.
- [x] Chart version bumped in `Chart.yaml` according to semver.
- [x] (optional) Parameters are documented in the README.md
