### PR TITLE
fix(nextcloud): add explicit group/kind to HTTPRoute backendRefs to prevent Argo CD drift

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.2.0
+version: 9.2.1
 # renovate: image=docker.io/library/nextcloud
 appVersion: 34.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/route.yaml
+++ b/charts/nextcloud/templates/route.yaml
@@ -27,7 +27,9 @@ spec:
   rules:
     {{- range .Values.httpRoute.rules }}
     - backendRefs:
-        - name: {{ $fullName }}
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
       {{- with .matches }}


### PR DESCRIPTION
## Description of the change

The HTTPRoute template rendered `backendRefs` with only `name`, `port`, and
`weight`. The Gateway API defaults `group: ""` and `kind: Service` server-side,
so the live object always contains two fields the Helm-rendered manifest omits.
Argo CD has no way to know these CRD defaults, so it reports the app `OutOfSync`
and re-syncs in a loop.

This renders `group: ""` and `kind: Service` explicitly so the desired manifest
matches the reconciled live state. No behavior change, no new values.

## Benefits

- Deterministic HTTPRoute rendering, compatible with GitOps / Argo CD
- No more continuous drift / re-sync loops on the generated HTTPRoute
- Users no longer need a custom `ignoreDifferences` rule on `.spec.rules[].backendRefs`

## Possible drawbacks

None. The two added fields are the effective API defaults the chart already relied on.

## Applicable issues

- fixes #857

## Additional information

Validated locally against `main`:
- `ct lint` (the CI gate) passes; chart version bump detected (9.2.0 -> 9.2.1)
- `helm lint --set httpRoute.enabled=true` passes
- `helm template` rendered with httpRoute disabled (no output), a default rule, and a custom filter+timeouts rule; `group`/`kind` present in every enabled case

## Checklist

- [X] I have read the CONTRIBUTING.md doc.
- [X] DCO has been signed off on the commit.
- [X] Chart version bumped in `Chart.yaml` according to semver.
- [ ] (optional) Parameters are documented in the README.md (no new parameters)
