### PR TITLE
fix(cronjob): change sidecar to cronstable for nonroot compatible (#733)

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.2.2
+version: 9.2.3
 # renovate: image=docker.io/library/nextcloud
 appVersion: 34.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/configmap-cronjob.yaml
+++ b/charts/nextcloud/templates/configmap-cronjob.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.cronjob.enabled (eq .Values.cronjob.type "sidecar") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-cronjob
+  labels:
+    {{- include "nextcloud.labels"  ( dict "rootContext" $ ) | nindent 4 }}
+data:
+  {{ with .Values.cronjob.sidecar }}
+  cronstable.yaml: |
+    jobs:
+      - name: cronjob
+        command: {{ .command | join " " | quote }}
+        schedule: {{ .schedule | quote }}
+        captureStdout: true
+  {{- end }}
+{{- end }}

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -243,8 +243,8 @@ spec:
         {{- if and .Values.cronjob.enabled (eq .Values.cronjob.type "sidecar") }}
         {{- with .Values.cronjob.sidecar }}
         - name: {{ $.Chart.Name }}-cron
-          image: {{ include "nextcloud.image" $ }}
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          image: "{{ coalesce $.Values.global.image.registry .registry }}/{{ .repository }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
           command:
             {{- toYaml .command | nindent 12 }}
           {{- with .lifecycle }}
@@ -272,6 +272,10 @@ spec:
           {{- end }}
           volumeMounts:
             {{- include "nextcloud.volumeMounts" $ | trim | nindent 12 }}
+            - name: nextcloud-cronjob
+              mountPath: /etc/cronstable.d/cronstable.yaml
+              subPath: cronstable.yaml
+              readOnly: true
         {{- end }}
         {{- end }}{{/* end-if cronjob.enabled */}}
         {{- with .Values.nextcloud.extraSidecarContainers }}
@@ -378,6 +382,11 @@ spec:
           configMap:
             name: {{ template "nextcloud.fullname" . }}-hooks
             defaultMode: 0o755
+        {{- end }}
+        {{- if and .Values.cronjob.enabled (eq .Values.cronjob.type "sidecar") }}
+        - name: nextcloud-cronjob
+          configMap:
+            name: {{ template "nextcloud.fullname" . }}-cronjob
         {{- end }}
         {{- with .Values.nextcloud.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -680,6 +680,16 @@ cronjob:
     ##
     resources: {}
 
+    image:
+      # -- cronstable image registry # can be docker.io and ghcr.io. docker.io has a rate-limit.
+      registry: ghcr.io
+      # -- cronstable image name
+      repository: ptweezy/cronstable
+      # -- cronstable image tag
+      tag: 1.2.24-alpine
+      # -- cronstable image pull policy
+      pullPolicy: IfNotPresent
+
     # Allow configuration of lifecycle hooks
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
     lifecycle: {}
@@ -693,9 +703,15 @@ cronjob:
     #   runAsNonRoot: true
     #   readOnlyRootFilesystem: true
 
-    # The command the cronjob container executes.
+    schedule: "*/5 * * * *"
+    # The command to run in the cronjob container
+    # Example to increase memory limit: php -d memory_limit=2G ...
     command:
-      - /cron.sh
+      - php
+      - -f
+      - /var/www/html/cron.php
+      - --
+      - --verbose
 
   # Uses a Kubernetes CronJob to execute the Nextcloud cron tasks
   # Note: can run as non-root user. Should run as same user as the Nextcloud pod.
@@ -751,7 +767,7 @@ cronjob:
     #   readOnlyRootFilesystem: true
 
     # The command to run in the cronjob container
-    # Example to incerase memory limit: php -d memory_limit=2G ...
+    # Example to increase memory limit: php -d memory_limit=2G ...
     command:
       - php
       - -f


### PR DESCRIPTION
## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
In shared Kubernetes environment which disable root containers, the cron as sidecar cannot work because cron implementation from alpine requires root. This change will replace to cronstable which is docker compliant and does not need root to work.

## Benefits

<!-- What benefits will be realized by the code change? -->
Can work in restricted Kubernetes environment:
- with non root policy
- without PV as readwrite many, so impossible to use cronjob as Kubernetes cronjob

## Possible drawbacks

<!-- Describe any known limitations with your change -->
Adds another image, but small footprint (~40MiB for alpine flavor)

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #733

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
