### PR TITLE
fix: nil pointer when evaluating when cronjob.enabled=true

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 9.2.3
+version: 9.2.4
 # renovate: image=docker.io/library/nextcloud
 appVersion: 34.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -271,7 +271,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.redis.enabled }}
+            {{- if $.Values.redis.enabled }}
             - name: php-confd
               mountPath: "/usr/local/etc/php/conf.d/redis-session.ini" # fix permission denied error
               subPath: redis-session.ini


### PR DESCRIPTION
## Description of the change

The `if` block checking if Redis is enabled needs to be anchored correctly since we are inside a `with` block (`with .Values.cronjob.sidecar`). Otherwise you get an error:

```
Error: nextcloud/templates/deployment.yaml:274:26
  executing "nextcloud/templates/deployment.yaml" at <.Values.redis.enabled>:
    nil pointer evaluating interface {}.redis
```

## Benefits

Makes the chart renderable with `--set cronjob.enabled=true`.

## Possible drawbacks

I believe this is the only occurrence but I might have missed an `{{- if .Values.redis.enabled }}` that needs to be `{{- if $.Values.redis.enabled }}` instead in some branch. I went through all the places where it was introduced in #752 but might have missed others.

## Applicable issues

- issue introduced in #752

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/nextcloud/helm/blob/main/CONTRIBUTING.md#pull-requests) doc.
- [x] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Parameters are documented in the README.md
